### PR TITLE
reside-146: Add a request method directly to the endpoint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgapi
 Title: Turn a Package into an HTTP API
-Version: 0.0.3
+Version: 0.0.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -135,14 +135,16 @@ pkgapi_endpoint <- R6::R6Class(
       }, error = pkgapi_process_error)
     },
 
-    ## @description Test the endpoint.  This creates a full plumber
-    ## object and serves one request to the endpoint.  Argument are as
-    ## passed through to \code{\link{pkgapi}}'s \code{$request()}
-    ## method, except that \code{method} and \code{path} are
-    ## automatically taken from the endpoint itself.
-    request = function(query = NULL, body = NULL, content_type = NULL) {
-      pkgapi$new()$handle(self)$request(self$method, self$path, query, body,
-                                        content_type)
+    ##' @description Test the endpoint.  This creates a full plumber
+    ##' object and serves one request to the endpoint.  Argument are as
+    ##' passed through to \code{\link{pkgapi}}'s \code{$request()}
+    ##' method, except that \code{method} and \code{path} are
+    ##' automatically taken from the endpoint itself.
+    ##'
+    ##' @param ... Arguments passed through to the \code{request} method
+    ##'   (\code{query}, \code{body} and \code{content_type}).
+    request = function(...) {
+      pkgapi$new()$handle(self)$request(self$method, self$path, ...)
     },
 
     ##' @description Helper method for use with plumber - not designed

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -135,6 +135,16 @@ pkgapi_endpoint <- R6::R6Class(
       }, error = pkgapi_process_error)
     },
 
+    ## @description Test the endpoint.  This creates a full plumber
+    ## object and serves one request to the endpoint.  Argument are as
+    ## passed through to \code{\link{pkgapi}}'s \code{$request()}
+    ## method, except that \code{method} and \code{path} are
+    ## automatically taken from the endpoint itself.
+    request = function(query = NULL, body = NULL, content_type = NULL) {
+      pkgapi$new()$handle(self)$request(self$method, self$path, query, body,
+                                        content_type)
+    },
+
     ##' @description Helper method for use with plumber - not designed
     ##' for end-user use.  This is what gets called by plumber when the
     ##' endpoint recieves a request.

--- a/man/pkgapi_endpoint.Rd
+++ b/man/pkgapi_endpoint.Rd
@@ -35,6 +35,7 @@ serialisation and validation information).}
 \itemize{
 \item \href{#method-new}{\code{pkgapi_endpoint$new()}}
 \item \href{#method-run}{\code{pkgapi_endpoint$run()}}
+\item \href{#method-request}{\code{pkgapi_endpoint$request()}}
 \item \href{#method-plumber}{\code{pkgapi_endpoint$plumber()}}
 }
 }
@@ -92,6 +93,27 @@ through the \code{process} method and returned by plumber) and
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{...}}{Arguments passed through to the \code{target} function}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-request"></a>}}
+\subsection{Method \code{request()}}{
+Test the endpoint.  This creates a full plumber
+object and serves one request to the endpoint.  Argument are as
+passed through to \code{\link{pkgapi}}'s \code{$request()}
+method, except that \code{method} and \code{path} are
+automatically taken from the endpoint itself.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{pkgapi_endpoint$request(...)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{...}}{Arguments passed through to the \code{request} method
+(\code{query}, \code{body} and \code{content_type}).}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-endpoint.R
+++ b/tests/testthat/test-endpoint.R
@@ -23,3 +23,19 @@ test_that("endpoints reject unconsumed dots", {
     "Unconsumed dot arguments: integer (unnamed argument)",
     fixed = TRUE)
 })
+
+
+test_that("Can serve endpoint directly", {
+  square <- function(n) {
+    jsonlite::unbox(n * n)
+  }
+  endpoint <- pkgapi_endpoint$new(
+    "GET", "/square", square,
+    returning = pkgapi_returning_json("Number", "schema"),
+    pkgapi_input_query(n = "numeric"),
+    validate = TRUE)
+
+  cmp <- pkgapi$new()$handle(endpoint)$request("GET", "/square", list(n = 3))
+  res <- endpoint$request(list(n = 3))
+  expect_equal(cmp, res)
+})


### PR DESCRIPTION
I've been doing this too much in tests, so we should make it easier!  This adds a `$request()` method that creates the full api with just one endpoint and then runs through all the plumber machinery.