### PR TITLE
reside-147: make it easier to control validation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgapi
 Title: Turn a Package into an HTTP API
-Version: 0.0.4
+Version: 0.0.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,5 +19,6 @@ Imports:
     jsonvalidate (>= 1.2.2),
     plumber
 Suggests:
-    testthat
+    testthat,
+    withr
 RoxygenNote: 7.0.2

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -170,6 +170,12 @@ pkgapi_endpoint <- R6::R6Class(
     },
 
     ##' @description Create a plumber endpoint
+    ##'
+    ##' @param envir Environment as used by plumber (currently unclear)
+    ##'
+    ##' @param validate Logical, allowing override of validation at the api
+    ##'   level.  This takes precedence over the value set when creating the
+    ##'   endpoint.
     create = function(envir, validate) {
       if (!identical(validate, self$validate)) {
         self <- self$clone()

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -8,7 +8,6 @@
 ##' @export
 pkgapi_endpoint <- R6::R6Class(
   "pkgapi_endpoint",
-  cloneable = FALSE,
 
   private = list(
     process = NULL,
@@ -168,5 +167,16 @@ pkgapi_endpoint <- R6::R6Class(
         args <- self$inputs$validate(given)
         do.call(self$run, args)
       }, error = pkgapi_process_error)
+    },
+
+    ##' @description Create a plumber endpoint
+    create = function(envir, validate) {
+      if (!identical(validate, self$validate)) {
+        self <- self$clone()
+        self$validate <- validate
+      }
+      plumber::PlumberEndpoint$new(
+        self$method, self$path, self$plumber, envir,
+        serializer = pkgapi_serialize_pass)
     }
   ))

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -42,12 +42,16 @@ pkgapi_endpoint <- R6::R6Class(
     ##' @param target An R function to run as the endpoint
     ##'
     ##' @param returning Information about what the endpoint returns,
-    ##    as created by \code{\link{pkgapi_returning}}
+    ##'    as created by \code{\link{pkgapi_returning}}
     ##'
     ##' @param validate Logical, indicating if any validation
-    ##' (implemented by the \code{validate_response} argument) should be
-    ##' enabled.  This should be set to \code{FALSE} in production
-    ##' environments.
+    ##'   (implemented by the \code{validate_response} argument) should
+    ##'   be enabled.  This should be set to \code{FALSE} in production
+    ##'   environments.  By default (if \code{validate} is \code{NULL}),
+    ##'   we look at the value of the environment \code{PKGAPI_VALIDATE}
+    ##'   - if \code{true} (case insensitive) then we will validate.
+    ##'   This is intended to support easy use of validation on
+    ##'   continuous integration systems.
     ##'
     ##' @param ... Additional parameters, currently representing
     ##' \emph{inputs}.  You can use the functions
@@ -60,7 +64,7 @@ pkgapi_endpoint <- R6::R6Class(
     ##' @param validate_response Optional function that throws an error
     ##' of the processed body is "invalid".
     initialize = function(method, path, target, ..., returning,
-                          validate = FALSE) {
+                          validate = NULL) {
       self$method <- method
       self$path <- path
       self$target <- target
@@ -110,7 +114,7 @@ pkgapi_endpoint <- R6::R6Class(
              call. = FALSE)
       }
 
-      self$validate <- validate
+      self$validate <- pkgapi_validate_default(validate)
       lock_bindings(
         c("method", "path", "target", "inputs", "state", "returning"),
         self)

--- a/R/validate.R
+++ b/R/validate.R
@@ -44,3 +44,12 @@ schema_root <- function(root) {
   assert_is_directory(root)
   normalizePath(root, mustWork = TRUE)
 }
+
+
+## Ugly name...
+pkgapi_validate_default <- function(value) {
+  if (is.null(value)) {
+    value <- tolower(Sys.getenv("PKGAPI_VALIDATE", "")) == "true"
+  }
+  value
+}

--- a/man/pkgapi.Rd
+++ b/man/pkgapi.Rd
@@ -50,13 +50,22 @@ A \code{pkgapi} object.  This extends (via
 \subsection{Method \code{new()}}{
 Create a pkgapi object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{pkgapi$new(...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{pkgapi$new(..., validate = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{...}}{Parameters passed to \code{\link{plumber}}}
+
+\item{\code{validate}}{Logical, indicating if any validation
+(implemented by the \code{validate_response} argument) should
+be enabled.  This should be set to \code{FALSE} in production
+environments.  By default (if \code{validate} is \code{NULL}),
+we look at the value of the environment \code{PKGAPI_VALIDATE}
+- if \code{true} (case insensitive) then we will validate.
+This is intended to support easy use of validation on
+continuous integration systems.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/pkgapi_endpoint.Rd
+++ b/man/pkgapi_endpoint.Rd
@@ -37,6 +37,8 @@ serialisation and validation information).}
 \item \href{#method-run}{\code{pkgapi_endpoint$run()}}
 \item \href{#method-request}{\code{pkgapi_endpoint$request()}}
 \item \href{#method-plumber}{\code{pkgapi_endpoint$plumber()}}
+\item \href{#method-create}{\code{pkgapi_endpoint$create()}}
+\item \href{#method-clone}{\code{pkgapi_endpoint$clone()}}
 }
 }
 \if{html}{\out{<hr>}}
@@ -44,7 +46,7 @@ serialisation and validation information).}
 \subsection{Method \code{new()}}{
 Create an endpoint
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{pkgapi_endpoint$new(method, path, target, ..., returning, validate = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{pkgapi_endpoint$new(method, path, target, ..., returning, validate = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -64,12 +66,17 @@ Create an endpoint
 them into this method.  The names used must match those in
 \code{target}.}
 
-\item{\code{returning}}{Information about what the endpoint returns,}
+\item{\code{returning}}{Information about what the endpoint returns,
+as created by \code{\link{pkgapi_returning}}}
 
 \item{\code{validate}}{Logical, indicating if any validation
-(implemented by the \code{validate_response} argument) should be
-enabled.  This should be set to \code{FALSE} in production
-environments.}
+(implemented by the \code{validate_response} argument) should
+be enabled.  This should be set to \code{FALSE} in production
+environments.  By default (if \code{validate} is \code{NULL}),
+we look at the value of the environment \code{PKGAPI_VALIDATE}
+- if \code{true} (case insensitive) then we will validate.
+This is intended to support easy use of validation on
+continuous integration systems.}
 
 \item{\code{validate_response}}{Optional function that throws an error
 of the processed body is "invalid".}
@@ -134,6 +141,42 @@ endpoint recieves a request.
 \item{\code{req, res}}{Conventional plumber request/response objects}
 
 \item{\code{...}}{Additional arguments passed through to \code{run}}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-create"></a>}}
+\subsection{Method \code{create()}}{
+Create a plumber endpoint
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{pkgapi_endpoint$create(envir, validate)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{envir}}{Environment as used by plumber (currently unclear)}
+
+\item{\code{validate}}{Logical, allowing override of validation at the api
+level.  This takes precedence over the value set when creating the
+endpoint.}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-clone"></a>}}
+\subsection{Method \code{clone()}}{
+The objects of this class are cloneable with this method.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{pkgapi_endpoint$clone(deep = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{deep}}{Whether to make a deep clone.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -110,6 +110,22 @@ test_that("can skip validation", {
 })
 
 
+test_that("validation respects default", {
+  f <- function() {
+    pkgapi_endpoint$new(
+    "GET", "/", function() jsonlite::unbox(1),
+    returning = pkgapi_returning_json("String", "schema"))$run()$status_code
+  }
+
+  withr::with_envvar(c("PKGAPI_VALIDATE" = NA_character_),
+                     expect_equal(f(), 200))
+  withr::with_envvar(c("PKGAPI_VALIDATE" = "false"),
+                     expect_equal(f(), 200))
+  withr::with_envvar(c("PKGAPI_VALIDATE" = "true"),
+                     expect_equal(f(), 500))
+})
+
+
 test_that("allow missing schema", {
   hello <- function() {
     jsonlite::unbox(1)

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -7,6 +7,27 @@ test_that("find schema root", {
 })
 
 
+test_that("default validation", {
+  withr::with_envvar(c("PKGAPI_VALIDATE" = NA_character_), {
+    expect_true(pkgapi_validate_default(TRUE))
+    expect_false(pkgapi_validate_default(FALSE))
+    expect_false(pkgapi_validate_default(NULL))
+  })
+
+  withr::with_envvar(c("PKGAPI_VALIDATE" = "true"), {
+    expect_true(pkgapi_validate_default(TRUE))
+    expect_false(pkgapi_validate_default(FALSE))
+    expect_true(pkgapi_validate_default(NULL))
+  })
+
+  withr::with_envvar(c("PKGAPI_VALIDATE" = "false"), {
+    expect_true(pkgapi_validate_default(TRUE))
+    expect_false(pkgapi_validate_default(FALSE))
+    expect_false(pkgapi_validate_default(NULL))
+  })
+})
+
+
 test_that("validate successful return", {
   path <- system_file("schema/response-success.json", package = "pkgapi")
   v <- jsonvalidate::json_validator(path, "ajv")

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -126,6 +126,20 @@ test_that("validation respects default", {
 })
 
 
+test_that("override validation defaults at the api level", {
+  endpoint <- pkgapi_endpoint$new(
+    "GET", "/", function() jsonlite::unbox(1),
+    returning = pkgapi_returning_json("String", "schema"),
+    validate = TRUE)
+  api <- pkgapi$new(validate = FALSE)
+  api$handle(endpoint)
+  expect_true(endpoint$validate)
+
+  expect_equal(endpoint$run()$status_code, 500)
+  expect_equal(api$request("GET", "/")$status, 200)
+})
+
+
 test_that("allow missing schema", {
   hello <- function() {
     jsonlite::unbox(1)


### PR DESCRIPTION
This PR adds two improvements to the validation

- the default now comes from the envvar `$PKGAPI_VALIDATE` which is the model we used in hintr
- the validation can be overridden at the api level

I also simplified the creation of the endpoint by moving some of the ugly code into the endpoint itself (not the pkgapi object)