### PR TITLE
reside-148: Allow plain plumber endpoints, fixing the swagger problem

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgapi
 Title: Turn a Package into an HTTP API
-Version: 0.0.5
+Version: 0.0.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/pkgapi.R
+++ b/R/pkgapi.R
@@ -36,9 +36,10 @@ pkgapi <- R6::R6Class(
 
     ##' @description Handle an endpoint
     ##'
-    ##' @param endpoint A \code{\link{pkgapi_endpoint}} object representing
-    ##' an endpoint.  Unlike plumber, an R function will \emph{not} work.
-    handle = function(endpoint) {
+    ##' @param ... Either a single argument, being a
+    ##'   \code{\link{pkgapi_endpoint}} object representing an endpoint, or
+    ##'  arguments to pass through to \code{plumber}.
+    handle = function(...) {
       ## NOTE: this ignores the 'preempt' arg - because the underlying
       ## logic of the super method uses missing() it's not
       ## straightforward to wrap.
@@ -50,8 +51,14 @@ pkgapi <- R6::R6Class(
       ##
       ## NOTE: We could use a different method here rather than
       ## overloading handle, as to add plain plumber endpoints.
-      assert_is(endpoint, "pkgapi_endpoint")
-      super$handle(endpoint = endpoint$create(private$envir, private$validate))
+      if (inherits(..1, "pkgapi_endpoint")) {
+        if (...length() > 1L) {
+          stop("nope!")
+        }
+        super$handle(endpoint = ..1$create(private$envir, private$validate))
+      } else {
+        super$handle(...)
+      }
       invisible(self)
     },
 

--- a/R/pkgapi.R
+++ b/R/pkgapi.R
@@ -53,7 +53,7 @@ pkgapi <- R6::R6Class(
       ## overloading handle, as to add plain plumber endpoints.
       if (inherits(..1, "pkgapi_endpoint")) {
         if (...length() > 1L) {
-          stop("nope!")
+          stop("If first argument is a 'pkgapi_endpoint' no others allowed")
         }
         super$handle(endpoint = ..1$create(private$envir, private$validate))
       } else {

--- a/man/pkgapi.Rd
+++ b/man/pkgapi.Rd
@@ -75,14 +75,15 @@ continuous integration systems.}
 \subsection{Method \code{handle()}}{
 Handle an endpoint
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{pkgapi$handle(endpoint)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{pkgapi$handle(...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{endpoint}}{A \code{\link{pkgapi_endpoint}} object representing
-an endpoint.  Unlike plumber, an R function will \emph{not} work.}
+\item{\code{...}}{Either a single argument, being a
+ \code{\link{pkgapi_endpoint}} object representing an endpoint, or
+arguments to pass through to \code{plumber}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-pkgapi.R
+++ b/tests/testthat/test-pkgapi.R
@@ -110,3 +110,15 @@ test_that("throw error", {
   expect_is(res$error, "pkgapi_error")
   expect_equal(res$error$status_code, 400)
 })
+
+
+test_that("allow plain plumber endpoints to be used", {
+  hello <- function() {
+    jsonlite::unbox("hello")
+  }
+  pr <- pkgapi$new()
+  pr$handle("GET", "/", hello)
+  res <- pr$request("GET", "/")
+  expect_equal(res$status, 200)
+  expect_equal(res$body, structure('"hello"', class = "json"))
+})

--- a/tests/testthat/test-pkgapi.R
+++ b/tests/testthat/test-pkgapi.R
@@ -122,3 +122,15 @@ test_that("allow plain plumber endpoints to be used", {
   expect_equal(res$status, 200)
   expect_equal(res$body, structure('"hello"', class = "json"))
 })
+
+
+test_that("disallow additional arguments with a pkgapendpoint", {
+  endpoint <- pkgapi_endpoint$new(
+    "GET", "/", function() jsonlite::unbox("hello"),
+    returning = pkgapi_returning_json("String", "schema"),
+    validate = TRUE)
+  pr <- pkgapi$new()
+  expect_error(
+    pr$handle(endpoint, "/hello"),
+    "If first argument is a 'pkgapi_endpoint' no others allowed")
+})


### PR DESCRIPTION
This PR fixes the problem that @r-ash noticed in the example package, where creating the api did not work unless `swagger = FALSE` was used.  While the currently generated swagger interface is useless this does at least prevent the error