### PR TITLE
reside-150: add 404 handler

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgapi
 Title: Turn a Package into an HTTP API
-Version: 0.0.6
+Version: 0.0.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/pkgapi.R
+++ b/R/pkgapi.R
@@ -130,7 +130,8 @@ pkgapi_error_handler <- function(req, res, e) {
 pkgapi_404_handler <- function(req, res) {
   e <- pkgapi_error_object(c("NOT_FOUND" = "Resource not found"), 404L)
   val <- pkgapi_process_error(e)
-  pkgapi_do_serialize_pass(val, res)
+  res$status <- 404
+  val$value$data <- jsonlite::unbox(NA)
   val$value
 }
 

--- a/R/pkgapi.R
+++ b/R/pkgapi.R
@@ -32,6 +32,7 @@ pkgapi <- R6::R6Class(
       super$initialize(NULL, pkgapi_filters(), new.env(parent = .GlobalEnv))
       private$validate <- validate
       self$setErrorHandler(pkgapi_error_handler)
+      self$set404Handler(pkgapi_404_handler)
     },
 
     ##' @description Handle an endpoint
@@ -121,6 +122,16 @@ pkgapi_do_serialize_pass <- function(val, res) {
 pkgapi_error_handler <- function(req, res, e) {
   val <- pkgapi_process_error(e)
   pkgapi_serialize_pass(val, req, res, function(...) NULL)
+}
+
+
+## This causes a proper fight with plumber as it bypasses all our
+## serialisers and error handlers in hard to deal with ways.
+pkgapi_404_handler <- function(req, res) {
+  e <- pkgapi_error_object(c("NOT_FOUND" = "Resource not found"), 404L)
+  val <- pkgapi_process_error(e)
+  pkgapi_do_serialize_pass(val, res)
+  val$value
 }
 
 

--- a/tests/testthat/test-endpoint.R
+++ b/tests/testthat/test-endpoint.R
@@ -37,6 +37,6 @@ test_that("Can serve endpoint directly", {
 
   cmp <- pkgapi$new()$handle(endpoint)$request("GET", "/square", list(n = 3))
   res <- endpoint$request(list(n = 3))
-  res$headers$Date <- cmp$headers$Date
+  res$headers[["Date"]] <- cmp$headers[["Date"]]
   expect_equal(cmp, res)
 })

--- a/tests/testthat/test-endpoint.R
+++ b/tests/testthat/test-endpoint.R
@@ -37,5 +37,6 @@ test_that("Can serve endpoint directly", {
 
   cmp <- pkgapi$new()$handle(endpoint)$request("GET", "/square", list(n = 3))
   res <- endpoint$request(list(n = 3))
+  res$headers$Date <- cmp$headers$Date
   expect_equal(cmp, res)
 })

--- a/tests/testthat/test-pkgapi.R
+++ b/tests/testthat/test-pkgapi.R
@@ -138,7 +138,6 @@ test_that("disallow additional arguments with a pkgapendpoint", {
 
 test_that("404 handler", {
   p <- pkgapi$new()
-  # # environment(p$initialize)$private$serializer
   res <- p$request("GET", "/somewhere")
   expect_equal(res$status, 404)
   expect_equal(res$headers[["Content-Type"]], "application/json")

--- a/tests/testthat/test-pkgapi.R
+++ b/tests/testthat/test-pkgapi.R
@@ -134,3 +134,18 @@ test_that("disallow additional arguments with a pkgapendpoint", {
     pr$handle(endpoint, "/hello"),
     "If first argument is a 'pkgapi_endpoint' no others allowed")
 })
+
+
+test_that("404 handler", {
+  p <- pkgapi$new()
+  # # environment(p$initialize)$private$serializer
+  res <- p$request("GET", "/somewhere")
+  expect_equal(res$status, 404)
+  expect_equal(res$headers[["Content-Type"]], "application/json")
+
+  cmp <- list(
+    status = jsonlite::unbox("failure"),
+    errors = pkgapi_error_data(list(NOT_FOUND = "Resource not found")),
+    data = NULL)
+  expect_equal(res$body, to_json(cmp))
+})


### PR DESCRIPTION
This PR adds a 404 handler that returns our standard response type (success/errors/data) rather than just plumber's default

```json
{"error":["404 - Resource Not Found"]}
```

which is not terribly useful.

Bypassing plumber's 404 handler is harder than you'd think and there's a good chance that when plumber upgrades this will need a tweak.
