### PR TITLE
reside-182: Update to work with recent plumber

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,5 @@ r_packages:
   - covr
 r_github_packages:
   - ropensci/jsonvalidate
-  - rstudio/plumber#659
 after_success:
   - Rscript -e 'covr::codecov(quiet = FALSE)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ r_packages:
   - covr
 r_github_packages:
   - ropensci/jsonvalidate
+  - rstudio/plumber#659
 after_success:
   - Rscript -e 'covr::codecov(quiet = FALSE)'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     R6,
     jsonlite,
     jsonvalidate (>= 1.2.2),
-    plumber (>= 0.9.9.9000)
+    plumber
 Suggests:
     testthat,
     withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     R6,
     jsonlite,
     jsonvalidate (>= 1.2.2),
-    plumber
+    plumber (>= 0.9.9.9000)
 Suggests:
     testthat,
     withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgapi
 Title: Turn a Package into an HTTP API
-Version: 0.0.9
+Version: 0.0.10
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -161,11 +161,9 @@ pkgapi_endpoint <- R6::R6Class(
     ##' @param req,res Conventional plumber request/response objects
     ##' @param ... Additional arguments passed through to \code{run}
     plumber = function(req, res, ...) {
-      ## It's not abundantly clear here what we do to get the path
-      ## args, and they cannot be retrieved from the filters it seems.
       tryCatch({
         given <- list(
-          path = req$args[seq_len(length(req$args) - 2L)],
+          path = req$argsPath,
           query = req$pkgapi_query,
           body = req$pkgapi_body)
         args <- self$inputs$validate(given)

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -163,7 +163,7 @@ pkgapi_endpoint <- R6::R6Class(
     plumber = function(req, res, ...) {
       tryCatch({
         given <- list(
-          path = req$argsPath,
+          path = plumber_path_args(req),
           query = req$pkgapi_query,
           body = req$pkgapi_body)
         args <- self$inputs$validate(given)

--- a/R/pkgapi.R
+++ b/R/pkgapi.R
@@ -7,7 +7,7 @@
 ##' @export
 pkgapi <- R6::R6Class(
   "pkgapi",
-  inherit = plumber::Plumber,
+  inherit = plumber_base_class(),
 
   private = list(
     validate = NULL

--- a/R/pkgapi.R
+++ b/R/pkgapi.R
@@ -7,7 +7,7 @@
 ##' @export
 pkgapi <- R6::R6Class(
   "pkgapi",
-  inherit = plumber::plumber,
+  inherit = plumber::Plumber,
 
   private = list(
     validate = NULL

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -6,7 +6,7 @@ NULL
 cache <- new.env()
 
 .onLoad <- function(...) {
-  cache$plumber_1_0_0 <- packageVersion("plumber") >= "0.9.9"
+  cache$plumber_1_0_0 <- utils::packageVersion("plumber") >= "0.9.9"
 }
 
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,30 @@
 ##' @importFrom R6 R6Class
 ##' @importFrom plumber plumber
 NULL
+
+
+cache <- new.env()
+
+.onLoad <- function(...) {
+  cache$plumber_1_0_0 <- packageVersion("plumber") >= "0.9.9"
+}
+
+
+## Compatibility:
+plumber_base_class <- function() {
+  get(plumber_base_class_name(), asNamespace("plumber"))
+}
+
+
+plumber_base_class_name <- function() {
+  if (cache$plumber_1_0_0) "Plumber" else "plumber"
+}
+
+
+plumber_path_args <- function(req) {
+  if (cache$plumber_1_0_0) {
+    req$argsPath
+  } else {
+    req$args[seq_len(length(req$args) - 2L)]
+  }
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,8 +5,8 @@ NULL
 
 cache <- new.env()
 
-.onLoad <- function(...) {
-  cache$plumber_1_0_0 <- utils::packageVersion("plumber") >= "0.9.9"
+.onLoad <- function(...) { # nolint
+  cache$plumber_1_0_0 <- utils::packageVersion("plumber") >= "0.9.9" # nocov
 }
 
 

--- a/tests/testthat/test-compat.R
+++ b/tests/testthat/test-compat.R
@@ -1,0 +1,29 @@
+context("compatibility")
+
+with_plumber_1_0_0 <- function(value, code) {
+  prev <- cache$plumber_1_0_0
+  on.exit(cache$plumber_1_0_0 <- prev)
+  cache$plumber_1_0_0 <- value
+  force(code)
+}
+
+test_that("base class under new and old plumber", {
+  with_plumber_1_0_0(
+    TRUE,
+    expect_equal(plumber_base_class_name(), "Plumber"))
+  with_plumber_1_0_0(
+    FALSE,
+    expect_equal(plumber_base_class_name(), "plumber"))
+})
+
+
+test_that("path handling under new", {
+  req <- list(argsPath = list(x = "a"),
+              args = list(y = "b", req = NULL, res = NULL))
+  with_plumber_1_0_0(
+    TRUE,
+    expect_equal(plumber_path_args(req), list(x = "a")))
+  with_plumber_1_0_0(
+    FALSE,
+    expect_equal(plumber_path_args(req), list(y = "b")))
+})


### PR DESCRIPTION
Minor changes, but they break everything.

I've made this change backward compatible, and so we can then depend on new pkgapi so our things gracefully cope with the upgrade, then once plumber 1.0.0 is on CRAN we can remove the compatibility layer.