### PR TITLE
reside-208: More flexible binary input checking

### DIFF
--- a/R/input-validate.R
+++ b/R/input-validate.R
@@ -54,9 +54,10 @@ porcelain_input_validate_mime <- function(given, expected) {
     porcelain_input_error(sprintf(
       "Content-Type was not set (expected '%s')", expected))
   }
-  if (given != expected) {
+  if (!(given %in% expected)) {
     porcelain_input_error(sprintf(
-      "Expected content type '%s' but was sent '%s'", expected, given))
+      "Expected content type %s but was sent '%s'",
+      paste(squote(expected), collapse = "|"), given))
   }
 }
 

--- a/R/input.R
+++ b/R/input.R
@@ -31,12 +31,19 @@ porcelain_input_query <- function(..., .parameters = list(...)) {
 ##'
 ##' @param name Name of the parameter
 ##'
+##' @param content_type Content type for the input. If not given, then
+##'   `application/octet-stream` is used. Provide a vector of valid
+##'   types to allow any of the types to be passed.
+##'
 ##' @export
 ##' @rdname porcelain_input_body
-porcelain_input_body_binary <- function(name) {
+porcelain_input_body_binary <- function(name, content_type = NULL) {
   assert_scalar_character(name)
+  if (is.null(content_type)) {
+    content_type <- "application/octet-stream"
+  }
   porcelain_input$new(name, "binary", "body", assert_raw,
-                   content_type = "application/octet-stream")
+                      content_type = content_type)
 }
 
 
@@ -47,7 +54,7 @@ porcelain_input_body_json <- function(name, schema, root) {
   assert_scalar_character(name)
   validator <- porcelain_validator(schema, schema_root(root), query = NULL)
   porcelain_input$new(name, "json", "body", validator,
-                   content_type = "application/json")
+                      content_type = "application/json")
 }
 
 

--- a/man/porcelain_input_body.Rd
+++ b/man/porcelain_input_body.Rd
@@ -5,12 +5,16 @@
 \alias{porcelain_input_body_json}
 \title{Control for body parameters}
 \usage{
-porcelain_input_body_binary(name)
+porcelain_input_body_binary(name, content_type = NULL)
 
 porcelain_input_body_json(name, schema, root)
 }
 \arguments{
 \item{name}{Name of the parameter}
+
+\item{content_type}{Content type for the input. If not given, then
+\code{application/octet-stream} is used. Provide a vector of valid
+types to allow any of the types to be passed.}
 
 \item{schema}{The name of the json schema to use}
 

--- a/tests/testthat/test-input-validate.R
+++ b/tests/testthat/test-input-validate.R
@@ -12,3 +12,11 @@ test_that("validate mime", {
           "but was sent 'application/octet-stream'"),
     fixed = TRUE, class = "porcelain_error")
 })
+
+
+test_that("validate mime can OR between allowable types", {
+  expect_error(
+    porcelain_input_validate_mime("a", c("b", "c")),
+    "Expected content type 'b'|'c' but was sent 'a'",
+    fixed = TRUE, class = "porcelain_error")
+})


### PR DESCRIPTION
Currently the binary body input requires that input has mime type application/octet-stream, which prevents the client from setting a mime type (httr will do this automatically based on the file extension). This PR lets this be tuneable and also allows for multiple mime-types to be allowed.