### PR TITLE
Report on validation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: porcelain
 Title: Turn a Package into an HTTP API
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -137,8 +137,11 @@ porcelain_endpoint <- R6::R6Class(
           self$returning$validate(body)
         }
         porcelain_response(self$returning$status_code,
-                           self$returning$content_type, body, data = data,
-                           headers = get_porcelain_headers(data))
+                           self$returning$content_type,
+                           body,
+                           data = data,
+                           headers = get_porcelain_headers(data),
+                           validated = self$validate)
       }, error = porcelain_process_error)
     },
 

--- a/R/error.R
+++ b/R/error.R
@@ -106,5 +106,5 @@ porcelain_process_error <- function(error) {
   body <- to_json_string(value)
   porcelain_response(status_code, content_type, body,
                      error = error, value = value,
-                     headers = NULL)
+                     headers = NULL, validated = FALSE)
 }

--- a/R/porcelain.R
+++ b/R/porcelain.R
@@ -22,15 +22,14 @@ porcelain <- R6::R6Class(
     ##'   (implemented by the \code{validate_response} argument) should
     ##'   be enabled.  This should be set to \code{FALSE} in production
     ##'   environments.  By default (if \code{validate} is \code{NULL}),
-    ##'   we look at the value of the environment
-    ##'   \code{PORCELAIN_VALIDATE} - if \code{true} (case insensitive)
-    ##'   then we will validate. This is intended to support easy use
-    ##'   of validation on continuous integration systems.
+    ##'   we look at the value of the environment \code{PORCELAIN_VALIDATE} -
+    ##'   if \code{true} (case insensitive) then we will validate.
+    ##'   This is intended to support easy use of validation on
+    ##'   continuous integration systems.
     initialize = function(..., validate = FALSE) {
       ## NOTE: it's not totally clear what the correct environment
       ## here is.
-      super$initialize(NULL, porcelain_filters(),
-                       new.env(parent = .GlobalEnv))
+      super$initialize(NULL, porcelain_filters(), new.env(parent = .GlobalEnv))
       private$validate <- porcelain_validate_default(validate)
       self$setErrorHandler(porcelain_error_handler)
       self$set404Handler(porcelain_404_handler)

--- a/R/porcelain.R
+++ b/R/porcelain.R
@@ -22,15 +22,16 @@ porcelain <- R6::R6Class(
     ##'   (implemented by the \code{validate_response} argument) should
     ##'   be enabled.  This should be set to \code{FALSE} in production
     ##'   environments.  By default (if \code{validate} is \code{NULL}),
-    ##'   we look at the value of the environment \code{PORCELAIN_VALIDATE} -
-    ##'   if \code{true} (case insensitive) then we will validate.
-    ##'   This is intended to support easy use of validation on
-    ##'   continuous integration systems.
+    ##'   we look at the value of the environment
+    ##'   \code{PORCELAIN_VALIDATE} - if \code{true} (case insensitive)
+    ##'   then we will validate. This is intended to support easy use
+    ##'   of validation on continuous integration systems.
     initialize = function(..., validate = FALSE) {
       ## NOTE: it's not totally clear what the correct environment
       ## here is.
-      super$initialize(NULL, porcelain_filters(), new.env(parent = .GlobalEnv))
-      private$validate <- validate
+      super$initialize(NULL, porcelain_filters(),
+                       new.env(parent = .GlobalEnv))
+      private$validate <- porcelain_validate_default(validate)
       self$setErrorHandler(porcelain_error_handler)
       self$set404Handler(porcelain_404_handler)
     },
@@ -91,11 +92,13 @@ porcelain <- R6::R6Class(
   ))
 
 
-porcelain_response <- function(status_code, content_type, body, headers, ...) {
+porcelain_response <- function(status_code, content_type, body, headers,
+                               validated, ...) {
   ret <- list(status_code = status_code,
               content_type = content_type,
               body = body,
               headers = headers,
+              validated = validated,
               ...)
   class(ret) <- "porcelain_response"
   ret
@@ -121,6 +124,8 @@ porcelain_do_serialize_pass <- function(val, res) {
       }
     }
   }
+  res$setHeader("X-Porcelain-Validated",
+                tolower(as.character(val$validated %||% FALSE)))
   if (val$content_type == "application/json") {
     res$body <- as.character(val$body)
   } else {

--- a/tests/testthat/test-porcelain.R
+++ b/tests/testthat/test-porcelain.R
@@ -16,12 +16,14 @@ test_that("wrap endpoint", {
   res <- endpoint$run()
   expect_is(res, "porcelain_response")
   expect_setequal(names(res),
-                  c("status_code", "content_type", "body", "data", "headers"))
+                  c("status_code", "content_type", "body", "data", "headers",
+                    "validated"))
   expect_equal(res$status_code, 200L)
   expect_equal(res$content_type, "application/json")
   expect_equal(res$body, to_json_string(response_success(res$data)))
   expect_equal(res$data, hello())
   expect_equal(res$headers, NULL)
+  expect_true(res$validated)
 
   expect_true(validator_response_success(res$body))
 })


### PR DESCRIPTION
This fixes a longstanding issue that it's not always obvious that validation has occured.

We now include a "validated" element in the result of endpoint$run and a header (X-Porcelain-Validated) in the response itself