### PR TITLE
Find schema root based on caller

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,6 +30,7 @@ jobs:
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     jsonvalidate (>= 1.2.2),
     plumber
 Suggests:
+    mockery,
     remotes,
     testthat,
     withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     plumber
 Suggests:
     mockery,
-    remotes,
+    pkgload,
     testthat,
     withr
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     jsonvalidate (>= 1.2.2),
     plumber
 Suggests:
+    remotes,
     testthat,
     withr
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Imports:
     jsonvalidate (>= 1.2.2),
     plumber
 Suggests:
-    pkgload,
     testthat,
     withr
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     jsonvalidate (>= 1.2.2),
     plumber
 Suggests:
+    pkgload,
     testthat,
     withr
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: porcelain
 Title: Turn a Package into an HTTP API
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/input.R
+++ b/R/input.R
@@ -52,7 +52,8 @@ porcelain_input_body_binary <- function(name, content_type = NULL) {
 ##' @rdname porcelain_input_body
 porcelain_input_body_json <- function(name, schema, root) {
   assert_scalar_character(name)
-  validator <- porcelain_validator(schema, schema_root(root), query = NULL)
+  root <- schema_root(root %||% parent.frame())
+  validator <- porcelain_validator(schema, root, query = NULL)
   porcelain_input$new(name, "json", "body", validator,
                       content_type = "application/json")
 }

--- a/R/returning.R
+++ b/R/returning.R
@@ -43,10 +43,10 @@ porcelain_returning <- function(content_type, process, validate,
 ##' @rdname porcelain_returning
 porcelain_returning_json <- function(schema = NULL, root = NULL,
                                      status_code = 200L) {
-  ## TODO(RESIDE-121): root can be inferred from the target function
+  root <- schema_root(root %||% parent.frame())
   content_type <- "application/json"
   process <- function(data) to_json_string(response_success(data))
-  validate <- porcelain_validator(schema, schema_root(root), query = "data")
+  validate <- porcelain_validator(schema, root, query = "data")
   porcelain_returning(content_type, process, validate, status_code)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -140,3 +140,30 @@ bind_args <- function(target, data) {
 
   as.function(c(keep, body), env)
 }
+
+
+## Find the root for included files (not including system files) for a
+## package. This corresponds to the "inst" directory.  This is
+## different when the package load has been simulated with
+## pkgload. This will come in useful in both tests and documentation.
+##
+## There are 4 cases here:
+##
+## porcelain real    + package real    => system.file is correct
+## porcelain pkgload + package real    => system.file is correct
+## porcelain real    + package pkgload => system.file is incorrect
+## porcelain pkgload + package pkgload => system.file is correct
+package_file_root <- function(package) {
+  path <- system.file(package = package, mustWork = TRUE)
+  if (pkgload_loaded() &&
+      pkgload::is_dev_package(package) &&
+      !pkgload::is_dev_package("porcelain")) {
+    path <- file.path(path, "inst")
+  }
+  path
+}
+
+
+pkgload_loaded <- function() {
+  "pkgload" %in% loadedNamespaces()
+}

--- a/R/validate.R
+++ b/R/validate.R
@@ -40,17 +40,6 @@ find_schema <- function(name, path) {
 }
 
 
-## nolint start
-## If we have access to the handler here we could find its schema root
-## with something like:
-##
-##   package <- utils::packageName(environment(handler))
-##   root <- system_file("schema", package = package)
-##
-## but that would need harmonising with any other schema use - and
-## that might want to come through the endpoint object or even the
-## whole porcelain object.
-## nolint end
 schema_root <- function(root) {
   if (is.environment(root)) {
     package <- utils::packageName(root)

--- a/R/validate.R
+++ b/R/validate.R
@@ -43,8 +43,8 @@ find_schema <- function(name, path) {
 schema_root <- function(root) {
   if (is.environment(root)) {
     package <- utils::packageName(root)
-    path_package <- system.file(package = package, mustWork = TRUE)
-    ## TODO: could allow this path to be customised by letting
+    path_package <- package_file_root(package)
+    ## TODO: co0uld allow this path to be customised by letting
     ## packages include this in DESCRIPTION as Config/porcelain/schema
     ## perhaps
     root <- file.path(path_package, "schema")

--- a/inst/examples/add/DESCRIPTION
+++ b/inst/examples/add/DESCRIPTION
@@ -1,0 +1,9 @@
+Package: add
+Title: Adds Numbers
+Version: 1.0.0
+Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
+                    email = "rich.fitzjohn@gmail.com"))
+Description: Adds numbers as an HTTP API.
+License: CC0
+Encoding: UTF-8
+Imports: porcelain

--- a/inst/examples/add/R/api.R
+++ b/inst/examples/add/R/api.R
@@ -1,0 +1,16 @@
+add <- function(a, b) {
+  jsonlite::unbox(a + b)
+}
+
+endpoint_add <- function() {
+  porcelain::porcelain_endpoint$new(
+    "GET", "/", add,
+    porcelain::porcelain_input_query(a = "numeric", b = "numeric"),
+    returning = porcelain::porcelain_returning_json("numeric"))
+}
+
+api <- function(validate = FALSE) {
+  api <- porcelain::porcelain$new(validate = validate)
+  api$handle(endpoint_add())
+  api
+}

--- a/inst/examples/add/inst/schema/numeric.json
+++ b/inst/examples/add/inst/schema/numeric.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "numeric",
+    "type": "number"
+}

--- a/tests/testthat/helper-porcelain.R
+++ b/tests/testthat/helper-porcelain.R
@@ -30,3 +30,8 @@ validator_response_failure <- jsonvalidate::json_validator(
 validator_response_success <- jsonvalidate::json_validator(
   system_file("schema/response-success.schema.json", package = "porcelain"),
   engine = "ajv")
+
+
+same_path <- function(a, b) {
+  normalizePath(a, "/", TRUE) == normalizePath(b, "/", TRUE)
+}

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -2,16 +2,12 @@ context("integration")
 
 test_that("Can run add package", {
   skip_on_cran()
-  skip_if_not_installed("remotes")
-  skip_on_os("windows") # usual issues getting packages installed on CI
-  lib <- tempfile()
-  dir.create(lib, FALSE, TRUE)
-  on.exit(unlink(lib, recursive = TRUE))
-  withr::local_libpaths(lib, "prefix")
-  add <- system_file("examples/add", package = "porcelain")
-  remotes::install_local(add, lib = lib, force = TRUE)
-  env <- loadNamespace("add", lib)
-  api <- env$api(TRUE)
+  skip_if_not_installed("pkgload")
+  path_pkg <- system_file("examples/add", package = "porcelain")
+  pkg <- pkgload::load_all(path_pkg, export_all = FALSE)
+  on.exit(pkgload::unload("add"))
+
+  api <- pkg$env$api(TRUE)
   res <- api$request("GET", "/", c(a = 1, b = 2))
   expect_equal(res$headers[["X-Porcelain-Validated"]], "true")
   expect_equal(from_json(res$body)$status, "success")

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -3,6 +3,7 @@ context("integration")
 test_that("Can run add package", {
   skip_on_cran()
   skip_if_not_installed("remotes")
+  skip_on_os("windows") # usual issues getting packages installed on CI
   lib <- tempfile()
   dir.create(lib, FALSE, TRUE)
   on.exit(unlink(lib, recursive = TRUE))

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -1,0 +1,19 @@
+context("integration")
+
+test_that("Can run add package", {
+  skip_on_cran()
+  lib <- tempfile()
+  dir.create(lib, FALSE, TRUE)
+  on.exit(unlink(lib, recursive = TRUE))
+  withr::local_libpaths(lib, "prefix")
+  add <- system_file("examples/add", package = "porcelain")
+
+  system2("R", c("CMD", "INSTALL", paste0("--library=", lib), add),
+          stdout = FALSE, stderr = FALSE)
+  env <- loadNamespace("add", lib)
+  api <- env$api(TRUE)
+  res <- api$request("GET", "/", c(a = 1, b = 2))
+  expect_equal(res$headers[["X-Porcelain-Validated"]], "true")
+  expect_equal(from_json(res$body)$status, "success")
+  expect_equal(from_json(res$body)$data, 3)
+})

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -2,14 +2,13 @@ context("integration")
 
 test_that("Can run add package", {
   skip_on_cran()
+  skip_if_not_installed("remotes")
   lib <- tempfile()
   dir.create(lib, FALSE, TRUE)
   on.exit(unlink(lib, recursive = TRUE))
   withr::local_libpaths(lib, "prefix")
   add <- system_file("examples/add", package = "porcelain")
-
-  system2("R", c("CMD", "INSTALL", paste0("--library=", lib), add),
-          stdout = FALSE, stderr = FALSE)
+  remotes::install_local(add, lib = lib, force = TRUE)
   env <- loadNamespace("add", lib)
   api <- env$api(TRUE)
   res <- api$request("GET", "/", c(a = 1, b = 2))

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -2,13 +2,16 @@ context("integration")
 
 test_that("Can run add package", {
   skip_on_cran()
-  skip_if_not_installed("pkgload")
-
+  lib <- tempfile()
+  dir.create(lib, FALSE, TRUE)
+  on.exit(unlink(lib, recursive = TRUE))
+  withr::local_libpaths(lib, "prefix")
   add <- system_file("examples/add", package = "porcelain")
-  pkg <- pkgload::load_all(add, export_all = FALSE)
-  on.exit(pkgload::unload("add"))
 
-  api <- pkg$env$api(TRUE)
+  system2("R", c("CMD", "INSTALL", paste0("--library=", lib), add),
+          stdout = FALSE, stderr = FALSE)
+  env <- loadNamespace("add", lib)
+  api <- env$api(TRUE)
   res <- api$request("GET", "/", c(a = 1, b = 2))
   expect_equal(res$headers[["X-Porcelain-Validated"]], "true")
   expect_equal(from_json(res$body)$status, "success")

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -2,16 +2,13 @@ context("integration")
 
 test_that("Can run add package", {
   skip_on_cran()
-  lib <- tempfile()
-  dir.create(lib, FALSE, TRUE)
-  on.exit(unlink(lib, recursive = TRUE))
-  withr::local_libpaths(lib, "prefix")
-  add <- system_file("examples/add", package = "porcelain")
+  skip_if_not_installed("pkgload")
 
-  system2("R", c("CMD", "INSTALL", paste0("--library=", lib), add),
-          stdout = FALSE, stderr = FALSE)
-  env <- loadNamespace("add", lib)
-  api <- env$api(TRUE)
+  add <- system_file("examples/add", package = "porcelain")
+  pkg <- pkgload::load_all(add, export_all = FALSE)
+  on.exit(pkgload::unload("add"))
+
+  api <- pkg$env$api(TRUE)
   res <- api$request("GET", "/", c(a = 1, b = 2))
   expect_equal(res$headers[["X-Porcelain-Validated"]], "true")
   expect_equal(from_json(res$body)$status, "success")

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -225,3 +225,24 @@ test_that("Find schema root", {
   expect_error(schema_root(environment(jsonlite::parse_json)),
                "File does not exist")
 })
+
+
+test_that("find schema by adding extensions", {
+  tmp <- tempfile()
+  dir.create(tmp)
+  tmp <- normalizePath(tmp)
+  expect_equal(find_schema("foo", tmp),
+               file.path(tmp, "foo"))
+
+  file.create(file.path(tmp, "foo.schema.json"))
+  expect_equal(find_schema("foo", tmp),
+               file.path(tmp, "foo.schema.json"))
+
+  file.create(file.path(tmp, "foo.json"))
+  expect_equal(find_schema("foo", tmp),
+               file.path(tmp, "foo.json"))
+
+  file.create(file.path(tmp, "foo"))
+  expect_equal(find_schema("foo", tmp),
+               file.path(tmp, "foo"))
+})

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -213,3 +213,13 @@ test_that("validate binary output", {
   res <- endpoint$run()
   expect_equal(res$status_code, 200L)
 })
+
+
+test_that("Find schema root", {
+  expect_equal(schema_root(environment(porcelain_validate)),
+               system_file("schema", package = "porcelain"))
+  expect_equal(schema_root(new.env(parent = environment(porcelain_validate))),
+               system_file("schema", package = "porcelain"))
+  expect_error(schema_root(environment(jsonlite::parse_json)),
+               "File does not exist")
+})

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -216,10 +216,12 @@ test_that("validate binary output", {
 
 
 test_that("Find schema root", {
-  expect_equal(schema_root(environment(porcelain_validate)),
-               system_file("schema", package = "porcelain"))
-  expect_equal(schema_root(new.env(parent = environment(porcelain_validate))),
-               system_file("schema", package = "porcelain"))
+  expect_true(same_path(
+    schema_root(environment(porcelain_validate)),
+    system_file("schema", package = "porcelain")))
+  expect_true(same_path(
+    schema_root(new.env(parent = environment(porcelain_validate))),
+    system_file("schema", package = "porcelain")))
   expect_error(schema_root(environment(jsonlite::parse_json)),
                "File does not exist")
 })


### PR DESCRIPTION
This sets things up to allow the schema root to be skipped when running from a package, by looking at the environment of the calling function. I've added a very small example package; we can add others (e.g., #3) later.