### PR TITLE
Support for logging from porcelain

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     jsonvalidate (>= 1.2.2),
     plumber
 Suggests:
+    lgr,
     mockery,
     pkgload,
     testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: porcelain
 Title: Turn a Package into an HTTP API
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/input.R
+++ b/R/input.R
@@ -50,7 +50,7 @@ porcelain_input_body_binary <- function(name, content_type = NULL) {
 ##' @inheritParams porcelain_returning_json
 ##' @export
 ##' @rdname porcelain_input_body
-porcelain_input_body_json <- function(name, schema, root) {
+porcelain_input_body_json <- function(name, schema = NULL, root = NULL) {
   assert_scalar_character(name)
   root <- schema_root(root %||% parent.frame())
   validator <- porcelain_validator(schema, root, query = NULL)

--- a/R/logging.R
+++ b/R/logging.R
@@ -1,0 +1,64 @@
+## To get a nice generic logger, what do we need to add?
+##
+## We need to control things like:
+##
+## * Where is it going? (we can do a lot with lgr to help here)
+## * What information are we capturing?
+
+
+## The simplest thing, we should be able to do:
+
+## pr$log(logger)
+
+## for some object 'logger' and have logging enabled, plus re-arrange
+## any existing hooks.
+
+## So for now, write a non-generic one and we'll make it generic later.
+
+porcelain_logger_basic <- R6::R6Class(
+  "porcelain_logger",
+
+  public = list(
+    initialize = function() {
+    },
+
+    log = function(msg) {
+      message(paste(sprintf("[%s] %s", Sys.time(), msg), collapse = "\n"))
+    }
+
+    begin = function(data, req, res) {
+      self$log(sprintf("%s %s", req$REQUEST_METHOD, req$PATH_INFO))
+    },
+
+    end = function(data, req, res, value) {
+      if (is.raw(res$body)) {
+        size <- length(res$body)
+      } else {
+        size <- nchar(res$body)
+      }
+      if (res$status >= 400 &&
+          identical(res$headers[["Content-Type"]], "application/json")) {
+        dat <- jsonlite::parse_json(res$body)
+        for (e in dat$errors) {
+          if (!is.null(e$error)) {
+            api_log(sprintf("error: %s", e$error))
+            api_log(sprintf("error-detail: %s", e$detail))
+            if (!is.null(e$trace)) {
+              trace <- sub("\n", " ", vcapply(e$trace, identity))
+              api_log(sprintf("error-trace: %s", trace))
+            }
+          }
+        }
+      }
+      self$log(sprintf("`--> %d (%d bytes)", res$status, size))
+    }
+  ))
+
+
+logger_safe <- function(fn) {
+  force(fn)
+  function(data, req, res, value) {
+    fn(data, req, res, value)
+    value
+  }
+}

--- a/R/logging.R
+++ b/R/logging.R
@@ -1,64 +1,56 @@
-## To get a nice generic logger, what do we need to add?
-##
-## We need to control things like:
-##
-## * Where is it going? (we can do a lot with lgr to help here)
-## * What information are we capturing?
+porcelain_log_preroute <- function(logger) {
+  force(logger)
+  function(data, req, res) {
+    logger$info("request %s %s", req$REQUEST_METHOD, req$PATH_INFO)
+    logger$trace("request",
+                 ## the remote address/port are unlikely to be
+                 ## interesting as noone should be exposing these APIs
+                 ## to the internet at large.
+                 ## remote_addr = req$REMOTE_ADDR,
+                 ## remote_port = req$REMOTE_PORT,
+                 method = req$REQUEST_METHOD,
+                 path = req$PATH_INFO,
+                 query = req$QUERY_STRING,
+                 headers = as.list(req$HEADERS))
+  }
+}
 
 
-## The simplest thing, we should be able to do:
+porcelain_log_postserialize <- function(logger) {
+  force(logger)
 
-## pr$log(logger)
-
-## for some object 'logger' and have logging enabled, plus re-arrange
-## any existing hooks.
-
-## So for now, write a non-generic one and we'll make it generic later.
-
-porcelain_logger_basic <- R6::R6Class(
-  "porcelain_logger",
-
-  public = list(
-    initialize = function() {
-    },
-
-    log = function(msg) {
-      message(paste(sprintf("[%s] %s", Sys.time(), msg), collapse = "\n"))
+  safe_body <- function(body) {
+    if (is.raw(body)) {
+      body <- sprintf("<binary body (%d bytes)>", length(body))
     }
+    body
+  }
 
-    begin = function(data, req, res) {
-      self$log(sprintf("%s %s", req$REQUEST_METHOD, req$PATH_INFO))
-    },
-
-    end = function(data, req, res, value) {
-      if (is.raw(res$body)) {
-        size <- length(res$body)
-      } else {
-        size <- nchar(res$body)
-      }
-      if (res$status >= 400 &&
-          identical(res$headers[["Content-Type"]], "application/json")) {
-        dat <- jsonlite::parse_json(res$body)
-        for (e in dat$errors) {
-          if (!is.null(e$error)) {
-            api_log(sprintf("error: %s", e$error))
-            api_log(sprintf("error-detail: %s", e$detail))
-            if (!is.null(e$trace)) {
-              trace <- sub("\n", " ", vcapply(e$trace, identity))
-              api_log(sprintf("error-trace: %s", trace))
-            }
+  function(data, req, res, value) {
+    if (is.raw(res$body)) {
+      size <- length(res$body)
+    } else {
+      size <- nchar(res$body)
+    }
+    if (res$status >= 400 &&
+        identical(res$headers[["Content-Type"]], "application/json")) {
+      dat <- jsonlite::parse_json(res$body)
+      for (e in dat$errors) {
+        if (!is.null(e$error)) {
+          api_log(sprintf("error: %s", e$error))
+          api_log(sprintf("error-detail: %s", e$detail))
+          if (!is.null(e$trace)) {
+            trace <- sub("\n", " ", vcapply(e$trace, identity))
+            api_log(sprintf("error-trace: %s", trace))
           }
         }
       }
-      self$log(sprintf("`--> %d (%d bytes)", res$status, size))
     }
-  ))
-
-
-logger_safe <- function(fn) {
-  force(fn)
-  function(data, req, res, value) {
-    fn(data, req, res, value)
+    logger$info(sprintf("response %d (%d bytes)", res$status, size))
+    logger$trace("response",
+                 status = value$status,
+                 headers = value$headers,
+                 body = safe_body(value$body))
     value
   }
 }

--- a/R/logging.R
+++ b/R/logging.R
@@ -1,5 +1,4 @@
-## Plumber has stages
-## preroute -> postroute -> preserialize -> postserialize
+## Plumber has stages preroute -> postroute -> preserialize -> postserialize
 ##
 ## We hook up the first bit of logging up against postroute as by that
 ## point we have run our filters, which include getting the body read

--- a/R/logging.R
+++ b/R/logging.R
@@ -54,24 +54,12 @@ logger_detailed <- function(logger, level, req, ...) {
   ## to the internet at large.
   ## remote_addr = req$REMOTE_ADDR,
   ## remote_port = req$REMOTE_PORT,
-
-  ## Because lgr used named arguments (and no programatic way of
-  ## providing this) we have to duplicate the entire call below. These
-  ## two calls are the same except that if if the body
-  if ("porcelain_body" %in% names(req)) {
-    logger[[level]](...,
-      method = req$REQUEST_METHOD,
-      path = req$PATH_INFO,
-      query = req$porcelain_query,
-      headers = as.list(req$HEADERS),
-      body = describe_body(req$porcelain_body$value))
-  } else {
-    logger[[level]](...,
-      method = req$REQUEST_METHOD,
-      path = req$PATH_INFO,
-      query = req$porcelain_query,
-      headers = as.list(req$HEADERS))
-  }
+  logger[[level]](...,
+    method = req$REQUEST_METHOD,
+    path = req$PATH_INFO,
+    query = req$porcelain_query,
+    headers = as.list(req$HEADERS),
+    body = describe_body(req$porcelain_body$value))
 }
 
 

--- a/R/porcelain.R
+++ b/R/porcelain.R
@@ -39,9 +39,7 @@ porcelain <- R6::R6Class(
 
       if (!is.null(logger)) {
         assert_is(logger, "Logger")
-        ## There is no way of detecting if a hook has been applied
-        ## already, or removing/replacing it.
-        self$registerHook("preroute", porcelain_log_preroute(logger))
+        self$registerHook("postroute", porcelain_log_postroute(logger))
         self$registerHook("postserialize", porcelain_log_postserialize(logger))
       }
     },

--- a/R/porcelain.R
+++ b/R/porcelain.R
@@ -26,13 +26,24 @@ porcelain <- R6::R6Class(
     ##'   if \code{true} (case insensitive) then we will validate.
     ##'   This is intended to support easy use of validation on
     ##'   continuous integration systems.
-    initialize = function(..., validate = FALSE) {
+    ##'
+    ##' @param logger Optional logger, from the `lgr` package.  If
+    ##'  given, then we will log at the beginning and end of the request.
+    initialize = function(..., validate = FALSE, logger = NULL) {
       ## NOTE: it's not totally clear what the correct environment
       ## here is.
       super$initialize(NULL, porcelain_filters(), new.env(parent = .GlobalEnv))
       private$validate <- porcelain_validate_default(validate)
       self$setErrorHandler(porcelain_error_handler)
       self$set404Handler(porcelain_404_handler)
+
+      if (!is.null(logger)) {
+        assert_is(logger, "Logger")
+        ## There is no way of detecting if a hook has been applied
+        ## already, or removing/replacing it.
+        self$registerHook("preroute", porcelain_log_preroute(logger))
+        self$registerHook("postserialize", porcelain_log_postserialize(logger))
+      }
     },
 
     ##' @description Handle an endpoint
@@ -87,10 +98,6 @@ porcelain <- R6::R6Class(
                        content_type = NULL) {
       plumber_request(self, method, path, query, body = body,
                       content_type = content_type)
-    },
-
-    set_logger = function(logger) {
-      browser()
     }
   ))
 

--- a/R/porcelain.R
+++ b/R/porcelain.R
@@ -87,6 +87,10 @@ porcelain <- R6::R6Class(
                        content_type = NULL) {
       plumber_request(self, method, path, query, body = body,
                       content_type = content_type)
+    },
+
+    set_logger = function(logger) {
+      browser()
     }
   ))
 

--- a/R/validate.R
+++ b/R/validate.R
@@ -34,6 +34,9 @@ porcelain_validator <- function(schema, root, query) {
 ## on 'name' if none are found. The fallback behaviour allows inlining
 ## schemas
 find_schema <- function(name, path) {
+  if (is.null(path)) {
+    stop("Did not find schema root")
+  }
   filename <- file.path(path, paste0(name, c("", ".json", ".schema.json")))
   exists <- file.exists(filename)
   filename[[if (any(exists)) which(exists)[[1L]] else 1L]]
@@ -43,6 +46,9 @@ find_schema <- function(name, path) {
 schema_root <- function(root) {
   if (is.environment(root)) {
     package <- utils::packageName(root)
+    if (is.null(package)) {
+      return(NULL)
+    }
     path_package <- package_file_root(package)
     ## TODO: co0uld allow this path to be customised by letting
     ## packages include this in DESCRIPTION as Config/porcelain/schema

--- a/man/porcelain.Rd
+++ b/man/porcelain.Rd
@@ -61,7 +61,7 @@ plumber API are documented here.
 \subsection{Method \code{new()}}{
 Create a porcelain object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{porcelain$new(..., validate = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{porcelain$new(..., validate = FALSE, logger = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -77,6 +77,9 @@ we look at the value of the environment \code{PORCELAIN_VALIDATE} -
 if \code{true} (case insensitive) then we will validate.
 This is intended to support easy use of validation on
 continuous integration systems.}
+
+\item{\code{logger}}{Optional logger, from the \code{lgr} package.  If
+given, then we will log at the beginning and end of the request.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/porcelain_input_body.Rd
+++ b/man/porcelain_input_body.Rd
@@ -7,7 +7,7 @@
 \usage{
 porcelain_input_body_binary(name, content_type = NULL)
 
-porcelain_input_body_json(name, schema, root)
+porcelain_input_body_json(name, schema = NULL, root = NULL)
 }
 \arguments{
 \item{name}{Name of the parameter}

--- a/tests/testthat/helper-porcelain.R
+++ b/tests/testthat/helper-porcelain.R
@@ -35,3 +35,21 @@ validator_response_success <- jsonvalidate::json_validator(
 same_path <- function(a, b) {
   normalizePath(a, "/", TRUE) == normalizePath(b, "/", TRUE)
 }
+
+
+test_logger <- function(name) {
+  testthat::skip_if_not_installed("lgr")
+  tmp <- tempfile()
+  logger <- lgr::get_logger(paste0("porcelain/tests/", name), reset = TRUE)
+  logger$set_propagate(FALSE)
+  logger$add_appender(lgr::AppenderJson$new(tmp), name = "json")
+  logger$set_threshold("all")
+  reg.finalizer(logger, function(e) unlink(tmp))
+  logger
+}
+
+
+test_logger_read <- function(logger) {
+  lapply(readLines(logger$appenders$json$destination), jsonlite::fromJSON,
+         simplifyDataFrame = FALSE)
+}

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -16,6 +16,23 @@ test_that("Can log", {
 
   log <- test_logger_read(logger)
   expect_length(log, 4)
+
+  expect_equal(log[[1]][c("caller", "msg")],
+               list(caller = "postroute", msg = "request GET /"))
+  expect_equal(
+    log[[2]][c("caller", "msg", "method", "path", "query", "headers")],
+    list(caller = "postroute", msg = "request", method = "GET", path = "/",
+         query = list(), headers = list()))
+
+  expect_equal(log[[3]][c("caller", "msg")],
+               list(caller = "postserialize",
+                    msg = "response GET / => 200 (49 bytes)"))
+  expect_equal(
+    log[[4]][c("caller", "msg", "method", "path", "query", "headers",
+               "body")],
+    list(caller = "postserialize", msg = "response", method = "GET", path = "/",
+         query = list(), headers = list(),
+         body = '{"status":"success","errors":null,"data":"hello"}'))
 })
 
 
@@ -59,6 +76,7 @@ test_that("log errors in a useful way", {
   expect_equal(log[[4]]$msg, "error")
   expect_equal(log[[4]]$errors,
                list(list(error = "an-error", detail = "An error has occured")))
+  expect_equal(log[[4]]$caller, "postserialize")
 })
 
 

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -1,0 +1,23 @@
+test_that("Can log", {
+  skip_if_not_installed("lgr")
+  hello <- function() {
+    jsonlite::unbox("hello")
+  }
+  endpoint <- porcelain_endpoint$new(
+    "GET", "/", hello,
+    returning = porcelain_returning_json("String", "schema"),
+    validate = TRUE)
+  tmp <- tempfile()
+  on.exit(unlink(tmp))
+  logger <- lgr::get_logger("porcelain/tests/can-log")
+  logger$set_propagate(FALSE)
+  logger$add_appender(lgr::AppenderJson$new(tmp), name = "json")
+  logger$set_threshold("all")
+
+  pr <- porcelain$new(logger = logger)
+  pr$handle(endpoint)
+  pr$request("GET", "/")
+
+  log <- lapply(readLines(tmp), jsonlite::fromJSON)
+  expect_length(log, 4)
+})

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -7,17 +7,82 @@ test_that("Can log", {
     "GET", "/", hello,
     returning = porcelain_returning_json("String", "schema"),
     validate = TRUE)
-  tmp <- tempfile()
-  on.exit(unlink(tmp))
-  logger <- lgr::get_logger("porcelain/tests/can-log")
-  logger$set_propagate(FALSE)
-  logger$add_appender(lgr::AppenderJson$new(tmp), name = "json")
-  logger$set_threshold("all")
+
+  logger <- test_logger("can-log")
 
   pr <- porcelain$new(logger = logger)
   pr$handle(endpoint)
   pr$request("GET", "/")
 
-  log <- lapply(readLines(tmp), jsonlite::fromJSON)
+  log <- test_logger_read(logger)
   expect_length(log, 4)
+})
+
+
+test_that("binary output is converted to safe trace output", {
+  skip_if_not_installed("lgr")
+  endpoint <- porcelain_endpoint$new(
+    "GET", "/", function() as.raw(0:255),
+    returning = porcelain_returning_binary(),
+    validate = TRUE)
+
+  logger <- test_logger("can-log-binary")
+
+  pr <- porcelain$new(logger = logger)
+  pr$handle(endpoint)
+  res <- pr$request("GET", "/")
+
+  log <- test_logger_read(logger)
+  expect_length(log, 4)
+  expect_equal(log[[4]]$body, "<binary body (256 bytes)>")
+})
+
+
+test_that("log errors in a useful way", {
+  hello <- function() {
+    porcelain_stop("An error has occured", "an-error")
+  }
+  err <- get_error(hello())
+
+  logger <- test_logger("error-single")
+
+  endpoint <- porcelain_endpoint$new(
+    "GET", "/", hello,
+    returning = porcelain_returning_json("String", "schema"))
+
+  pr <- porcelain$new(logger = logger)
+  pr$handle(endpoint)
+  res <- pr$request("GET", "/")
+
+  log <- test_logger_read(logger)
+  expect_length(log, 5)
+
+  expect_equal(log[[4]]$msg, "error")
+  expect_equal(log[[4]]$errors,
+               list(list(error = "an-error", detail = "An error has occured")))
+})
+
+
+test_that("log multiple errors into a single log entry", {
+  hello <- function() {
+    porcelain_stop("An error has occured", "an-error",
+                   list(ERROR1 = "message1", ERROR2 = "message2"))
+  }
+  err <- get_error(hello())
+
+  logger <- test_logger("error-multiple")
+  endpoint <- porcelain_endpoint$new(
+    "GET", "/", hello,
+    returning = porcelain_returning_json("String", "schema"))
+
+  pr <- porcelain$new(logger = logger)
+  pr$handle(endpoint)
+  res <- pr$request("GET", "/")
+
+  log <- test_logger_read(logger)
+  expect_length(log, 5)
+  expect_equal(log[[4]]$msg, "error")
+  expect_equal(log[[4]]$errors,
+               list(list(error = "ERROR1", detail = "message1"),
+                    list(error = "ERROR2", detail = "message2")))
 })

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -246,3 +246,10 @@ test_that("find schema by adding extensions", {
   expect_equal(find_schema("foo", tmp),
                file.path(tmp, "foo"))
 })
+
+
+test_that("sensible output returned for impossible root", {
+  expect_null(schema_root(globalenv()))
+  expect_error(find_schema("foo", NULL),
+               "Did not find schema root")
+})


### PR DESCRIPTION
This PR adds optional support for logging. We're using the lgr package here, which has some nice features we can use - multiple appenders, nice handling of json, controllable reporting levels etc.

I've set this up so that the user passes in a configured logging object to the api constructor. This means that lgr is really an optional dependency and indeed anything else that matches its api would work.

I've tried to match approximately the format used in orderly.server / hintr though we'll need to update tests there if they depend too much on the details