### PR TITLE
Allow json body to be destructured on input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: porcelain
 Title: Turn a Package into an HTTP API
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ LazyData: true
 Language: en-GB
 Imports:
     R6,
+    V8,
     jsonlite,
     jsonvalidate (>= 1.2.2),
     plumber

--- a/R/utils.R
+++ b/R/utils.R
@@ -167,3 +167,9 @@ package_file_root <- function(package) {
 pkgload_loaded <- function() {
   "pkgload" %in% loadedNamespaces()
 }
+
+
+json_parse_depth1 <- function(json) {
+  assert_scalar_character(json)
+  cache$v8$call("jsonParseDepth1", json)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -169,14 +169,6 @@ pkgload_loaded <- function() {
 }
 
 
-json_parse_depth1 <- function(json) {
-  assert_scalar_character(json)
-  cache$v8$call("jsonParseDepth1", json)
-}
-
-
 json_parse_extract <- function(json, name) {
-  assert_scalar_character(json)
-  assert_scalar_character(name)
   cache$v8$call("jsonParseExtract", json, name)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -173,3 +173,10 @@ json_parse_depth1 <- function(json) {
   assert_scalar_character(json)
   cache$v8$call("jsonParseDepth1", json)
 }
+
+
+json_parse_extract <- function(json, name) {
+  assert_scalar_character(json)
+  assert_scalar_character(name)
+  cache$v8$call("jsonParseExtract", json, name)
+}

--- a/R/validate.R
+++ b/R/validate.R
@@ -17,7 +17,7 @@ porcelain_validate <- function(json, validator, query) {
 ## environment variable to also require it in tests.
 porcelain_validator <- function(schema, root, query) {
   if (is.null(schema)) {
-    return(function(...) NULL)
+    return(function(json) invisible(json))
   }
   force(query)
   path_schema <- find_schema(schema, root)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -6,7 +6,11 @@ NULL
 cache <- new.env()
 
 .onLoad <- function(...) { # nolint
-  cache$plumber_1_0_0 <- utils::packageVersion("plumber") >= "0.9.9" # nocov
+  ## nocov start
+  cache$plumber_1_0_0 <- utils::packageVersion("plumber") >= "0.9.9"
+  cache$v8 <- V8::new_context()
+  cache$v8$source(system_file("utils.js", package = "porcelain"))
+  ## nocov end
 }
 
 

--- a/inst/utils.js
+++ b/inst/utils.js
@@ -3,13 +3,24 @@
 // more direct access to a json parser might be more efficient (if we
 // knew the start/end positions of each entry we could clip them from
 // the input string).
-var jsonParseDepth1 = function(x) {
-  if (x.length === 0 || x[0] !== "{") {
-    throw "Provided json is not an object";
-  }
-  var data = JSON.parse(x);
-  for (const key of Object.keys(data)) {
-    data[key] = JSON.stringify(data[key]);
-  }
-  return data;
+function jsonParseDepth1(x) {
+    if (x.length === 0 || x[0] !== "{") {
+        throw "Provided json is not an object";
+    }
+    var data = JSON.parse(x);
+    for (const key of Object.keys(data)) {
+        data[key] = JSON.stringify(data[key]);
+    }
+    return data;
+}
+
+function jsonParseExtract(x, key) {
+    if (x.length === 0 || x[0] !== "{") {
+        throw "Provided json is not an object";
+    }
+    var data = JSON.parse(x);
+    if (!(key in data)) {
+        throw "Did not find key '" + key + "' within object";
+    }
+    return JSON.stringify(data[key]);
 }

--- a/inst/utils.js
+++ b/inst/utils.js
@@ -1,0 +1,15 @@
+// Given a json object, return an object of json strings corresponding
+// to each entry. This does require one round of parse/stringify and
+// more direct access to a json parser might be more efficient (if we
+// knew the start/end positions of each entry we could clip them from
+// the input string).
+var jsonParseDepth1 = function(x) {
+  if (x.length === 0 || x[0] !== "{") {
+    throw "Provided json is not an object";
+  }
+  var data = JSON.parse(x);
+  for (const key of Object.keys(data)) {
+    data[key] = JSON.stringify(data[key]);
+  }
+  return data;
+}

--- a/inst/utils.js
+++ b/inst/utils.js
@@ -1,19 +1,4 @@
-// Given a json object, return an object of json strings corresponding
-// to each entry. This does require one round of parse/stringify and
-// more direct access to a json parser might be more efficient (if we
-// knew the start/end positions of each entry we could clip them from
-// the input string).
-function jsonParseDepth1(x) {
-    if (x.length === 0 || x[0] !== "{") {
-        throw "Provided json is not an object";
-    }
-    var data = JSON.parse(x);
-    for (const key of Object.keys(data)) {
-        data[key] = JSON.stringify(data[key]);
-    }
-    return data;
-}
-
+/*eslint no-unused-vars: "off"*/
 function jsonParseExtract(x, key) {
     if (x.length === 0 || x[0] !== "{") {
         throw "Provided json is not an object";

--- a/man/porcelain_input_body.Rd
+++ b/man/porcelain_input_body.Rd
@@ -7,7 +7,7 @@
 \usage{
 porcelain_input_body_binary(name, content_type = NULL)
 
-porcelain_input_body_json(name, schema = NULL, root = NULL)
+porcelain_input_body_json(name, schema = NULL, root = NULL, extract = NULL)
 }
 \arguments{
 \item{name}{Name of the parameter}
@@ -19,6 +19,14 @@ types to allow any of the types to be passed.}
 \item{schema}{The name of the json schema to use}
 
 \item{root}{The root of the schema directory.}
+
+\item{extract}{Optionally, the name of an element to extract from
+the json. If given, then the body must be a json object (not an
+array, for example) and \code{extract} must refer to a top-level key
+within it. We will extract the \emph{JSON string} corresponding to
+this key and forward that to the argument \code{name}.
+Deserialisation of the json is still the target function's
+responsibility but there will be less of it.}
 }
 \description{
 Control for body parameters.  This might change.  There are

--- a/tests/testthat/test-input.R
+++ b/tests/testthat/test-input.R
@@ -631,7 +631,7 @@ test_that("destructure body failure returns input error", {
     porcelain_input_body_json("b", extract = "b"),
     returning = porcelain_returning_json())
   pr <- porcelain$new(validate = TRUE)$handle(endpoint)
-  res <- pr$request("POST", "/multiply", body = '{}')
+  res <- pr$request("POST", "/multiply", body = "{}")
   expect_equal(res$status, 400)
   expect_equal(res$headers,
                list("Content-Type" = "application/json",

--- a/tests/testthat/test-input.R
+++ b/tests/testthat/test-input.R
@@ -599,3 +599,50 @@ test_that("default parameters", {
   expect_equal(res_api$headers[["Content-Type"]], "application/json")
   expect_equal(res_api$body, res$body)
 })
+
+
+test_that("destructure body", {
+  multiply <- function(a, b) {
+    jsonlite::unbox(as.numeric(a) * as.numeric(b))
+  }
+  endpoint <- porcelain_endpoint$new(
+    "POST", "/multiply", multiply,
+    porcelain_input_body_json("a", extract = "a"),
+    porcelain_input_body_json("b", extract = "b"),
+    returning = porcelain_returning_json())
+  pr <- porcelain$new(validate = TRUE)$handle(endpoint)
+  json <- '{"a": 3, "b": 2}'
+  res <- pr$request("POST", "/multiply", body = json)
+  expect_equal(res$status, 200)
+  expect_equal(res$headers,
+               list("Content-Type" = "application/json",
+                    "X-Porcelain-Validated" = "true"))
+  expect_equal(res$body, endpoint$run("3", "2")$body)
+})
+
+
+test_that("destructure body failure returns input error", {
+  multiply <- function(a, b) {
+    jsonlite::unbox(as.numeric(a) * as.numeric(b))
+  }
+  endpoint <- porcelain_endpoint$new(
+    "POST", "/multiply", multiply,
+    porcelain_input_body_json("a", extract = "a"),
+    porcelain_input_body_json("b", extract = "b"),
+    returning = porcelain_returning_json())
+  pr <- porcelain$new(validate = TRUE)$handle(endpoint)
+  res <- pr$request("POST", "/multiply", body = '{}')
+  expect_equal(res$status, 400)
+  expect_equal(res$headers,
+               list("Content-Type" = "application/json",
+                    "X-Porcelain-Validated" = "false"))
+  err <- jsonlite::fromJSON(res$body, simplifyDataFrame = FALSE)
+  expect_equal(
+    err,
+    list(status = "failure",
+         errors = list(
+           list(error = "INVALID_INPUT",
+                detail = paste("Error parsing body (for 'a'):",
+                               "Did not find key 'a' within object"))),
+         data = NULL))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -108,3 +108,19 @@ test_that("detect package root under pkgload", {
   mockery::expect_called(mock_pkgload_loaded, 4)
   mockery::expect_called(mock_is_dev_package, 5)
 })
+
+
+test_that("destructure body", {
+  a <- "[1, 2, 3]"
+  b <- '{"x": 1, "y": 2}'
+  json <- sprintf('{"a": %s, "b": %s}', a, b)
+
+  ## Standardise json spacing:
+  std_json <- function(x) {
+    cache$v8$eval(sprintf("JSON.stringify(JSON.parse('%s'))", x))
+  }
+
+  expect_equal(json_parse_depth1(json),
+               list(a = std_json(a),
+                    b = std_json(b)))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -124,3 +124,24 @@ test_that("destructure body", {
                list(a = std_json(a),
                     b = std_json(b)))
 })
+
+
+test_that("extract from body", {
+  a <- "[1, 2, 3]"
+  b <- '{"x": 1, "y": 2}'
+  json <- sprintf('{"a": %s, "b": %s}', a, b)
+
+  ## Standardise json spacing:
+  std_json <- function(x) {
+    cache$v8$eval(sprintf("JSON.stringify(JSON.parse('%s'))", x))
+  }
+
+  expect_equal(json_parse_extract(json, "a"), std_json(a))
+  expect_equal(json_parse_extract(json, "b"), std_json(b))
+  expect_error(json_parse_extract(json, "c"),
+               "Did not find key 'c' within object")
+  expect_error(json_parse_extract("", "c"),
+               "Provided json is not an object")
+  expect_error(json_parse_extract(a, "c"),
+               "Provided json is not an object")
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -110,22 +110,6 @@ test_that("detect package root under pkgload", {
 })
 
 
-test_that("destructure body", {
-  a <- "[1, 2, 3]"
-  b <- '{"x": 1, "y": 2}'
-  json <- sprintf('{"a": %s, "b": %s}', a, b)
-
-  ## Standardise json spacing:
-  std_json <- function(x) {
-    cache$v8$eval(sprintf("JSON.stringify(JSON.parse('%s'))", x))
-  }
-
-  expect_equal(json_parse_depth1(json),
-               list(a = std_json(a),
-                    b = std_json(b)))
-})
-
-
 test_that("extract from body", {
   a <- "[1, 2, 3]"
   b <- '{"x": 1, "y": 2}'


### PR DESCRIPTION
Currently we allow forwarding the json body to one argument of a function. However, if we have a function that wants parts of the json, this is a bit awkward.

This PR allows writing 

```r
porcelain_input_body_json("arg", extract = "key")
```

to extract the element `key` from a json body and forwarding it to the target function argument `arg`. Multiple such entries are allowed.

Currently we do not support deserialisation in `porcelain_input_body_json`, forwarding just the json string, so here we extract the *string* corresponding to the entry - a little js utility is used for this to avoid serialisation round-trip errors.
