### PR TITLE
Don't load testthat helpers on background server

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: porcelain
 Title: Turn a Package into an HTTP API
-Version: 0.1.6
+Version: 0.1.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/background.R
+++ b/R/background.R
@@ -234,7 +234,8 @@ background_user_hook <- function(path_src) {
     NULL
   } else {
     bquote(pkgload::load_all(
-      .(path_src), export_all = FALSE, attach_testthat = FALSE))
+      .(path_src), export_all = FALSE, attach_testthat = FALSE,
+      helpers = FALSE))
   }
 }
 

--- a/tests/testthat/test-background.R
+++ b/tests/testthat/test-background.R
@@ -105,7 +105,8 @@ test_that("user hook empty if path_src not given", {
   expect_equal(
     background_user_hook("path"),
     quote(
-      pkgload::load_all("path", export_all = FALSE, attach_testthat = FALSE)))
+      pkgload::load_all("path", export_all = FALSE, attach_testthat = FALSE,
+                        helpers = FALSE)))
 })
 
 


### PR DESCRIPTION
Otherwise in hintr we are seeing the helpers set "USE_MOCK_MODEL" to true and have no way to override it via the `env` arg to `porcelain_background$new`