### PR TITLE
Remove package use of unexported plumber symbols

### DIFF
--- a/R/filter.R
+++ b/R/filter.R
@@ -5,7 +5,7 @@ porcelain_filters <- function(req, res) {
 
 
 porcelain_filter_query_string <- function(req, res) {
-  req$porcelain_query <- plumber:::parseQS(req$QUERY_STRING)
+  req$porcelain_query <- parse_query(req$QUERY_STRING)
   plumber::forward()
 }
 

--- a/R/query.R
+++ b/R/query.R
@@ -23,13 +23,13 @@
 ## rather than silently dropping the 'b' part of the query.
 parse_query <- function(query) {
   if (length(query) == 0L || query == "") {
-    return(NULL)
+    return(list())
   }
 
   query <- chartr("+", " ", sub("^\\?", "", query))
   args <- strsplit(strsplit(query, "&", fixed = TRUE)[[1]], "=", fixed = TRUE)
   if (length(args) == 0) {
-    return(NULL)
+    return(list())
   }
   
   keys <- trimws(vcapply(args, "[[", 1L))

--- a/R/query.R
+++ b/R/query.R
@@ -31,7 +31,7 @@ parse_query <- function(query) {
   if (length(args) == 0) {
     return(list())
   }
-  
+
   keys <- trimws(vcapply(args, "[[", 1L))
   err <- lengths(args) != 2
   if (any(err)) {
@@ -41,7 +41,7 @@ parse_query <- function(query) {
   }
   args <- lapply(args, function(x) trimws(utils::URLdecode(x)))
 
-  vals <- lapply(args, "[[", 2L)  
+  vals <- lapply(args, "[[", 2L)
 
   if (anyDuplicated(keys)) {
     ## TODO: This should be a 400 error, as it's bad input. As is,

--- a/R/query.R
+++ b/R/query.R
@@ -1,0 +1,57 @@
+## This is not as sophisticated as plumber's parseQS function, but we
+## can't use that as it's not exported. We make the assumption that
+## the encoding is straightforward, and that there is only a single
+## item for each key
+##
+## It's possible that the encoding issue will go away with the newer
+## builds of windows that use a UTF-8 based runtime. See this github
+## thread for discussion:
+##
+## https://github.com/rstudio/plumber/pull/314#discussion_r239992879
+##
+## It's not actually obvious what the correct thing to do with
+## duplicate query keys, see:
+##
+##   https://stackoverflow.com/q/1746507
+##
+## So in keeping with what we typically do here (provide a
+## comma-separated list as as a single query parameter) and in keeping
+## with pushing for type stability, we'll forbid duplicate keys. This
+## is also easier to implement!
+##
+## We also explicitly reject incomplete queries (e.g., "?a=1&b=&c=3")
+## rather than silently dropping the 'b' part of the query.
+parse_query <- function(query) {
+  if (length(query) == 0L || query == "") {
+    return(NULL)
+  }
+
+  query <- chartr("+", " ", sub("^\\?", "", query))
+  args <- strsplit(strsplit(query, "&", fixed = TRUE)[[1]], "=", fixed = TRUE)
+  if (length(args) == 0) {
+    return(NULL)
+  }
+  
+  keys <- trimws(vcapply(args, "[[", 1L))
+  err <- lengths(args) != 2
+  if (any(err)) {
+    ## TODO: should be 400 not 500 error
+    stop(sprintf("Incomplete query for %s",
+                 paste(squote(keys[err]), collapse = ", ")))
+  }
+  args <- lapply(args, function(x) trimws(utils::URLdecode(x)))
+
+  vals <- lapply(args, "[[", 2L)  
+
+  if (anyDuplicated(keys)) {
+    ## TODO: This should be a 400 error, as it's bad input. As is,
+    ## this will likely end up as a 500 error.
+    stop(sprintf(
+      "Unexpected duplicate keys %s",
+      paste(squote(unique(keys[duplicated(keys)])), collapse = ", ")))
+  }
+
+  names(vals) <- keys
+
+  vals
+}

--- a/R/request.R
+++ b/R/request.R
@@ -14,23 +14,7 @@ plumber_request <- function(plumber, method, path, query = NULL,
     req[["HTTP_CONTENT_TYPE"]] <- request_content_type(body, content_type)
   }
 
-  res <- plumber_response()
-  plumber$serve(req, res)
-}
-
-
-## TODO: we might not really need the whole thing here, but this is
-## a problem potentially.  The input interface (res) folllows the Rook format
-##
-## https://www.rplumber.io/docs/routing-and-input.html#input-handling
-## but the response format is undocumented
-##
-## https://www.rplumber.io/docs/rendering-and-output.html#response-object
-##
-## The format is described and conforms to the Rook interface but this
-## class is not exported.
-plumber_response <- function() {
-  plumber:::PlumberResponse$new()
+  plumber$call(req)
 }
 
 

--- a/tests/testthat/helper-porcelain.R
+++ b/tests/testthat/helper-porcelain.R
@@ -113,5 +113,6 @@ skip_if_no_roxygen <- function() {
 
 
 plumber_response <- function() {
+  testthat::skip_on_cran() # using plumber internals, subject to change
   plumber:::PlumberResponse$new()
 }

--- a/tests/testthat/helper-porcelain.R
+++ b/tests/testthat/helper-porcelain.R
@@ -110,3 +110,8 @@ skip_if_no_roxygen <- function() {
   testthat::skip_if_not_installed("roxygen2")
   testthat::skip_if_not_installed("pkgload")
 }
+
+
+plumber_response <- function() {
+  plumber:::PlumberResponse$new()
+}

--- a/tests/testthat/test-background.R
+++ b/tests/testthat/test-background.R
@@ -71,7 +71,7 @@ test_that("Failure to start returns sensible information", {
   err <- expect_error(bg$start())
 
   expect_s3_class(err, "porcelain_background_error")
-  expect_match(err$message, "unused argument")
+  expect_match(format(err), "unused argument", all = FALSE)
   expect_match(err$log, "Loading add", all = FALSE)
   expect_match(err$log, "unused argument", all = FALSE)
 })

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -14,9 +14,9 @@ test_that("special characters in query strings are handled properly", {
 
 
 test_that("null an empty strings return empty list", {
-  expect_null(parse_query(NULL))
-  expect_null(parse_query(""))
-  expect_null(parse_query("?"))
+  expect_equal(parse_query(NULL), list())
+  expect_equal(parse_query(""), list())
+  expect_equal(parse_query("?"), list())
 })
 
 

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -9,7 +9,7 @@ test_that("query strings are properly parsed", {
 test_that("special characters in query strings are handled properly", {
   expect_equal(parse_query("?a=1+.#"), list(a = "1 .#"))
   expect_equal(parse_query("?a=a%20b"), list(a = "a b"))
-  expect_equal(parse_query('?a = %2C%2B%2F%3F%25%26'), list(a = ",+/?%&"))
+  expect_equal(parse_query("?a = %2C%2B%2F%3F%25%26"), list(a = ",+/?%&"))
 })
 
 

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -22,7 +22,8 @@ test_that("null and empty strings return empty list", {
 
 test_that("incomplete query strings are errors", {
   expect_error(parse_query("a="), "Incomplete query for 'a'")
-  expect_error(parse_query("a=1&b=&c&d=1"), "Incomplete query for 'b', 'c'")
+  expect_error(parse_query("a=1&b=&c=&d=1"), "Incomplete query for 'b', 'c'")
+  expect_error(parse_query("a=1&b&c&d=1"), "Incomplete query for 'b', 'c'")
 })
 
 

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -1,0 +1,34 @@
+test_that("query strings are properly parsed", {
+  expect_equal(parse_query("?a=1"), list(a = "1"))
+  expect_equal(parse_query("b=2"), list(b = "2"))
+  expect_equal(parse_query("a=1&b=2&c=url%20encoded"),
+               list(a = "1", b = "2", c = "url encoded"))
+})
+
+
+test_that("special characters in query strings are handled properly", {
+  expect_equal(parse_query("?a=1+.#"), list(a = "1 .#"))
+  expect_equal(parse_query("?a=a%20b"), list(a = "a b"))
+  expect_equal(parse_query('?a = %2C%2B%2F%3F%25%26'), list(a = ",+/?%&"))
+})
+
+
+test_that("null an empty strings return empty list", {
+  expect_null(parse_query(NULL))
+  expect_null(parse_query(""))
+  expect_null(parse_query("?"))
+})
+
+
+test_that("incomplete query strings are errors", {
+  expect_error(parse_query("a="), "Incomplete query for 'a'")
+  expect_error(parse_query("a=1&b=&c&d=1"), "Incomplete query for 'b', 'c'")
+})
+
+
+test_that("query strings with duplicates are errors", {
+  expect_error(parse_query("a=1&a=2&a=3&a=4"),
+               "Unexpected duplicate keys 'a'")
+  expect_error(parse_query("a=1&b=2&b=3&c=4&c=5"),
+               "Unexpected duplicate keys 'b', 'c'")
+})

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -13,7 +13,7 @@ test_that("special characters in query strings are handled properly", {
 })
 
 
-test_that("null an empty strings return empty list", {
+test_that("null and empty strings return empty list", {
   expect_equal(parse_query(NULL), list())
   expect_equal(parse_query(""), list())
   expect_equal(parse_query("?"), list())


### PR DESCRIPTION
This PR removes use of two unexported plumber calls - one to the `PlumberResponse` class (replaced by a call to a method on the plumber object which achieves the same thing) and the other to `parseQS` to parse a query string (replaced by a new implementation with some minor interface differences)