### PR TITLE
Enforce that target must be a function

### DIFF
--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -67,6 +67,7 @@ porcelain_endpoint <- R6::R6Class(
       self$method <- method
       self$path <- path
       self$target <- target
+      assert_is(target, "function")
       assert_is(returning, "porcelain_returning")
       self$returning <- returning
 

--- a/tests/testthat/test-background.R
+++ b/tests/testthat/test-background.R
@@ -71,7 +71,7 @@ test_that("Failure to start returns sensible information", {
   err <- expect_error(bg$start())
 
   expect_s3_class(err, "porcelain_background_error")
-  expect_match(err$message, "unused argument")
+  expect_match(format(err), "unused argument", all = FALSE)
   expect_match(err$log, "Loading add", all = FALSE)
   expect_match(err$log, "unused argument", all = FALSE)
 })

--- a/tests/testthat/test-endpoint.R
+++ b/tests/testthat/test-endpoint.R
@@ -38,3 +38,12 @@ test_that("Can serve endpoint directly", {
   res$headers[["Date"]] <- cmp$headers[["Date"]]
   expect_equal(cmp, res)
 })
+
+
+test_that("target must be a function", {
+  expect_error(porcelain::porcelain_endpoint$new(
+    "GET", "/",
+    porcelain::porcelain_input_query(a = "numeric", b = "numeric"),
+    returning = porcelain::porcelain_returning_binary()),
+    "'target' must be a function")
+})


### PR DESCRIPTION
This PR checks that the endpoint target is a function, throwing a better error than currently