### PR TITLE
Allow passing NA query parameter to plumber request

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: porcelain
 Title: Turn a Package into an HTTP API
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/request.R
+++ b/R/request.R
@@ -23,6 +23,9 @@ query_string <- function(query) {
     return("")
   }
   assert_named(query)
+  ## On input we map '?param=' to list(param = NA) so we map back to this
+  ## query string for testing
+  query[is.na(query)] <- ""
   pairs <- sprintf("%s=%s", names(query), as.character(query))
   utils::URLencode(paste0("?", paste(pairs, collapse = "&")))
 }

--- a/tests/testthat/test-input.R
+++ b/tests/testthat/test-input.R
@@ -230,6 +230,26 @@ test_that("Can validate query parameters from plumber, throwing nice errors", {
 })
 
 
+test_that("NA query parameters are valid", {
+  multiply <- porcelain_endpoint$new(
+    "GET", "/multiply", function(a, b) {
+      if (is.na(a)) {
+        a <- 10
+      }
+      jsonlite::unbox(a * b)
+    },
+    porcelain_input_query(a = "numeric", b = "numeric"),
+    returning = porcelain_returning_json())
+
+  api <- porcelain$new()$handle(multiply)
+
+  res <- api$request("GET", "/multiply", c(a = NA_real_, b = 2))
+  expect_equal(res$status, 200)
+  expect_equal(res$headers[["Content-Type"]], "application/json")
+  expect_equal(res$body, multiply$run(10, 2)$body)
+})
+
+
 test_that("use routing parameter", {
   power <- function(n, m = 2) {
     jsonlite::unbox(n^m)


### PR DESCRIPTION
Since #31 we can accept an empty query. For testing we need to be able to map back to it, this PR will mean `plumber_request` will map a query like `list(x = NA)` to `?x=`