### PR TITLE
Use default value from target function if query is empty

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: porcelain
 Title: Turn a Package into an HTTP API
-Version: 0.1.11
+Version: 0.1.12
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/input.R
+++ b/R/input.R
@@ -151,12 +151,13 @@ porcelain_input <- R6::R6Class(
 ## query and path (eventually also cookie and header)
 porcelain_input_validate_parameter <- function(given, self) {
   value <- given[[self$where]][[self$name]]
-  if (self$required && (is.null(value) || is.na(value))) {
+  missing_value <- is.null(value) || is.na(value)
+  if (self$required && missing_value) {
     porcelain_input_error(sprintf(
       "%s parameter '%s' is missing but required",
       self$where, self$name))
   }
-  if (!is.null(value) && !is.na(value)) {
+  if (!missing_value) {
     value <- tryCatch(
       self$validator(value),
       error = function(e)

--- a/R/input.R
+++ b/R/input.R
@@ -151,18 +151,20 @@ porcelain_input <- R6::R6Class(
 ## query and path (eventually also cookie and header)
 porcelain_input_validate_parameter <- function(given, self) {
   value <- given[[self$where]][[self$name]]
-  if (self$required && is.null(value)) {
+  if (self$required && (is.null(value) || is.na(value))) {
     porcelain_input_error(sprintf(
       "%s parameter '%s' is missing but required",
       self$where, self$name))
   }
-  if (!is.null(value)) {
+  if (!is.null(value) && !is.na(value)) {
     value <- tryCatch(
       self$validator(value),
       error = function(e)
         ## NOTE: not a lovely error message for the body
         porcelain_input_error(sprintf("Error parsing %s parameter '%s': %s",
                                    self$where, self$name, e$message)))
+  } else {
+    value <- self$default
   }
   value
 }

--- a/tests/testthat/test-input.R
+++ b/tests/testthat/test-input.R
@@ -244,7 +244,8 @@ test_that("NA query parameters throw an error", {
   expect_equal(res$status, 400)
   errors <- jsonlite::parse_json(res$body, simplifyVector = FALSE)$errors
   expect_equal(errors[[1]]$error, "INVALID_INPUT")
-  expect_equal(errors[[1]]$detail, "query parameter 'a' is missing but required")
+  expect_equal(errors[[1]]$detail,
+               "query parameter 'a' is missing but required")
 })
 
 test_that("NA query parameters are valid when target has default values", {


### PR DESCRIPTION
This PR will
* Update endpoint handling so that if an endpoint receives an empty query it will use the default value from the function. If there is no default value then it will error