### PR TITLE
Add request received and elapsed time info to logger

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -35,11 +35,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -18,9 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: porcelain
 Title: Turn a Package into an HTTP API
-Version: 0.1.12
+Version: 0.1.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/filter.R
+++ b/R/filter.R
@@ -1,6 +1,7 @@
 porcelain_filters <- function(req, res) {
   list(query_string = porcelain_filter_query_string,
-       post_body = porcelain_filter_post_body)
+       post_body = porcelain_filter_post_body,
+       metadata = porcelain_filter_metadata)
 }
 
 
@@ -25,4 +26,10 @@ porcelain_filter_post_body <- function(req, res) {
 
 porcelain_body <- function(type, value) {
   list(type = type, value = value, provided = length(value) > 0L)
+}
+
+
+porcelain_filter_metadata <- function(req, res) {
+  req$received_time <- Sys.time()
+  plumber::forward()
 }

--- a/R/filter.R
+++ b/R/filter.R
@@ -30,6 +30,6 @@ porcelain_body <- function(type, value) {
 
 
 porcelain_filter_metadata <- function(req, res) {
-  req$received_time <- Sys.time()
+  req$received_time <- now_utc()
   plumber::forward()
 }

--- a/R/logging.R
+++ b/R/logging.R
@@ -50,10 +50,8 @@ porcelain_logger <- function(log_level = "info", name = NULL, path = NULL) {
 porcelain_log_postroute <- function(logger) {
   force(logger)
   function(data, req, res) {
-    duration <- now_utc() - req$received_time
     logger$info("request %s %s", req$REQUEST_METHOD, req$PATH_INFO,
-                caller = "postroute", request_received = req$received_time,
-                elapsed = format(duration))
+                caller = "postroute")
     logger_detailed(logger, "trace", req, "postroute", "request")
   }
 }
@@ -73,13 +71,10 @@ porcelain_log_postserialize <- function(logger) {
     } else {
       size <- nchar(res$body)
     }
-
-    duration <- now_utc() - req$received_time
-
     logger$info(sprintf("response %s %s => %d (%d bytes)",
                         req$REQUEST_METHOD, req$PATH_INFO, res$status, size),
                 caller = "postserialize", request_received = req$received_time,
-                elapsed = format(duration))
+                elapsed = format_difftime(now_utc(), req$received_time))
 
     if (is_json_error_response(res)) {
       logger_detailed(logger, "error", req, "postserialize", "error",

--- a/R/logging.R
+++ b/R/logging.R
@@ -50,7 +50,7 @@ porcelain_logger <- function(log_level = "info", name = NULL, path = NULL) {
 porcelain_log_postroute <- function(logger) {
   force(logger)
   function(data, req, res) {
-    duration <- Sys.time() - req$received_time
+    duration <- now_utc() - req$received_time
     logger$info("request %s %s", req$REQUEST_METHOD, req$PATH_INFO,
                 caller = "postroute", request_received = req$received_time,
                 elapsed = format(duration))
@@ -74,7 +74,7 @@ porcelain_log_postserialize <- function(logger) {
       size <- nchar(res$body)
     }
 
-    duration <- Sys.time() - req$received_time
+    duration <- now_utc() - req$received_time
 
     logger$info(sprintf("response %s %s => %d (%d bytes)",
                         req$REQUEST_METHOD, req$PATH_INFO, res$status, size),

--- a/R/logging.R
+++ b/R/logging.R
@@ -50,8 +50,10 @@ porcelain_logger <- function(log_level = "info", name = NULL, path = NULL) {
 porcelain_log_postroute <- function(logger) {
   force(logger)
   function(data, req, res) {
+    duration <- Sys.time() - req$received_time
     logger$info("request %s %s", req$REQUEST_METHOD, req$PATH_INFO,
-                caller = "postroute")
+                caller = "postroute", request_received = req$received_time,
+                elapsed = format(duration))
     logger_detailed(logger, "trace", req, "postroute", "request")
   }
 }
@@ -72,9 +74,12 @@ porcelain_log_postserialize <- function(logger) {
       size <- nchar(res$body)
     }
 
+    duration <- Sys.time() - req$received_time
+
     logger$info(sprintf("response %s %s => %d (%d bytes)",
                         req$REQUEST_METHOD, req$PATH_INFO, res$status, size),
-                caller = "postserialize")
+                caller = "postserialize", request_received = req$received_time,
+                elapsed = format(duration))
 
     if (is_json_error_response(res)) {
       logger_detailed(logger, "error", req, "postserialize", "error",

--- a/R/utils.R
+++ b/R/utils.R
@@ -278,26 +278,22 @@ now_utc <- function() {
 ## Modified version of difftime to show timings
 ## in ms and to a precision
 format_difftime <- function(time1, time2) {
-  z <- unclass(time1) - unclass(time2)
-  attr(z, "tzone") <- NULL
-  units <- if (all(is.na(z))) {
+  z <- as.numeric(time1 - time2, "secs")
+  units <- if (!is.finite(z) || z <= 1) {
+    "ms"
+  } else if (z < 60) {
     "secs"
+  } else if (z < 3600) {
+    "mins"
   } else {
-    diff <- min(abs(z), na.rm = TRUE)
-    if (!is.finite(diff) || diff <= 1) {
-      "ms"
-    } else if (diff < 60) {
-      "secs"
-    } else if (diff < 3600) {
-      "mins"
-    } else {
-      "hours"
-    }
+    "hours"
   }
-  time <- switch(units,
-                 ms = z * 1000,
-                 secs = z,
-                 mins = z / 60,
-                 hours = z / 3600)
-  paste(round(time, 2), units)
+  units_difftime <- if (units == "ms") "secs" else units
+  z <- as.numeric(time1 - time2, units_difftime)
+  if (units == "ms") {
+    z <- z * 1000
+    sprintf("%.0f %s", z, units)
+  } else {
+    sprintf("%.2f %s", z, units)
+  }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -271,3 +271,7 @@ package_name <- function(env) {
   utils::packageName(env)
 }
 
+now_utc <- function() {
+  as.POSIXlt(Sys.time(), tz = "UTC")
+}
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -270,3 +270,4 @@ list_call <- function(fn, x) {
 package_name <- function(env) {
   utils::packageName(env)
 }
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -272,6 +272,32 @@ package_name <- function(env) {
 }
 
 now_utc <- function() {
-  as.POSIXlt(Sys.time(), tz = "UTC")
+  as.POSIXct(Sys.time(), tz = "UTC")
 }
 
+## Modified version of difftime to show timings
+## in ms and to a precision
+format_difftime <- function(time1, time2) {
+  z <- unclass(time1) - unclass(time2)
+  attr(z, "tzone") <- NULL
+  units <- if (all(is.na(z))) {
+    "secs"
+  } else {
+    diff <- min(abs(z), na.rm = TRUE)
+    if (!is.finite(diff) || diff <= 1) {
+      "ms"
+    } else if (diff < 60) {
+      "secs"
+    } else if (diff < 3600) {
+      "mins"
+    } else {
+      "hours"
+    }
+  }
+  time <- switch(units,
+                 ms = z * 1000,
+                 secs = z,
+                 mins = z / 60,
+                 hours = z / 3600)
+  paste(round(time, 2), units)
+}

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -19,6 +19,10 @@ test_that("Can log", {
 
   expect_equal(log[[1]][c("caller", "msg")],
                list(caller = "postroute", msg = "request GET /"))
+  datetime_pattern <- "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"
+  expect_match(log[[1]]$request_received, datetime_pattern)
+  expect_match(log[[1]]$elapsed, "\\d.\\d+ \\w+")
+
   expect_equal(
     log[[2]][c("caller", "msg", "method", "path", "query", "headers")],
     list(caller = "postroute", msg = "request", method = "GET", path = "/",
@@ -27,6 +31,10 @@ test_that("Can log", {
   expect_equal(log[[3]][c("caller", "msg")],
                list(caller = "postserialize",
                     msg = "response GET / => 200 (49 bytes)"))
+  datetime_pattern <- "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"
+  expect_match(log[[1]]$request_received, datetime_pattern)
+  expect_match(log[[1]]$elapsed, "\\d.\\d+ \\w+")
+
   expect_equal(
     log[[4]][c("caller", "msg", "method", "path", "query", "headers",
                "body")],

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -19,9 +19,6 @@ test_that("Can log", {
 
   expect_equal(log[[1]][c("caller", "msg")],
                list(caller = "postroute", msg = "request GET /"))
-  datetime_pattern <- "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"
-  expect_match(log[[1]]$request_received, datetime_pattern)
-  expect_match(log[[1]]$elapsed, "\\d.\\d+ \\w+")
 
   expect_equal(
     log[[2]][c("caller", "msg", "method", "path", "query", "headers")],
@@ -32,8 +29,8 @@ test_that("Can log", {
                list(caller = "postserialize",
                     msg = "response GET / => 200 (49 bytes)"))
   datetime_pattern <- "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"
-  expect_match(log[[1]]$request_received, datetime_pattern)
-  expect_match(log[[1]]$elapsed, "\\d.\\d+ \\w+")
+  expect_match(log[[3]]$request_received, datetime_pattern)
+  expect_match(log[[3]]$elapsed, "\\d.\\d+ \\w+")
 
   expect_equal(
     log[[4]][c("caller", "msg", "method", "path", "query", "headers",

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -30,7 +30,7 @@ test_that("Can log", {
                     msg = "response GET / => 200 (49 bytes)"))
   datetime_pattern <- "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"
   expect_match(log[[3]]$request_received, datetime_pattern)
-  expect_match(log[[3]]$elapsed, "\\d.\\d+ \\w+")
+  expect_match(log[[3]]$elapsed, "\\d+ \\w+")
 
   expect_equal(
     log[[4]][c("caller", "msg", "method", "path", "query", "headers",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -142,3 +142,16 @@ test_that("try and find a free port", {
     fixed = TRUE)
   mockery::expect_called(mock_check_port, 5)
 })
+
+
+test_that("can format difftime nicely", {
+  now <- Sys.time()
+  expect_match(format_difftime(Sys.time(), now), "\\d{1,3}.\\d{2} ms")
+  expect_match(format_difftime(now, Sys.time()), "-\\d{1,3}.\\d{2} ms")
+  expect_equal(format_difftime(now, now), "0 ms")
+
+  expect_match(format_difftime(now, (now - 1)), "1000 ms")
+  expect_match(format_difftime(now, (now - 1.1)), "1.1 secs")
+  expect_match(format_difftime(now, (now - 65)), "1.08 mins")
+  expect_match(format_difftime(now, (now - 60 * 60)), "1 hours")
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -145,13 +145,14 @@ test_that("try and find a free port", {
 
 
 test_that("can format difftime nicely", {
-  now <- Sys.time()
-  expect_match(format_difftime(Sys.time(), now), "\\d{1,3}.\\d{1,2} ms")
-  expect_match(format_difftime(now, Sys.time()), "-\\d{1,3}.\\d{1,2} ms")
-  expect_equal(format_difftime(now, now), "0 ms")
+  base_time <- ISOdate(2022, 11, 11, 10, 49, 33.123)
 
-  expect_match(format_difftime(now, (now - 1)), "1000 ms")
-  expect_match(format_difftime(now, (now - 1.1)), "1.1 secs")
-  expect_match(format_difftime(now, (now - 65)), "1.08 mins")
-  expect_match(format_difftime(now, (now - 60 * 60)), "1 hours")
+  expect_equal(format_difftime(base_time, base_time), "0 ms")
+  expect_match(format_difftime(base_time + 0.5, base_time), "\\d{1,4} ms")
+  expect_match(format_difftime(base_time - 0.5, base_time), "-\\d{1,4} ms")
+
+  expect_match(format_difftime(base_time, (base_time - 1)), "1000 ms")
+  expect_match(format_difftime(base_time, (base_time - 1.1)), "1.10 secs")
+  expect_match(format_difftime(base_time, (base_time - 65)), "1.08 mins")
+  expect_match(format_difftime(base_time, (base_time - 60 * 60)), "1.00 hours")
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -146,8 +146,8 @@ test_that("try and find a free port", {
 
 test_that("can format difftime nicely", {
   now <- Sys.time()
-  expect_match(format_difftime(Sys.time(), now), "\\d{1,3}.\\d{2} ms")
-  expect_match(format_difftime(now, Sys.time()), "-\\d{1,3}.\\d{2} ms")
+  expect_match(format_difftime(Sys.time(), now), "\\d{1,3}.\\d{1,2} ms")
+  expect_match(format_difftime(now, Sys.time()), "-\\d{1,3}.\\d{1,2} ms")
   expect_equal(format_difftime(now, now), "0 ms")
 
   expect_match(format_difftime(now, (now - 1)), "1000 ms")


### PR DESCRIPTION
This PR will
* Add `request_received` date time in UTC and elapsed time to `postserialize` log message

I think this will be generally useful info to have but I specifically want to see this for hintr to confirm that the load issues we are having are because hintr is responding slowly to some requests.

I added a custom formatter here instead of using the default difftime formatter because I want to see the times formatting in ms. As I can see default formatters lowest unit is seconds.