### PR TITLE
Return endpoint info from logger

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: porcelain
 Title: Turn a Package into an HTTP API
-Version: 0.1.14
+Version: 0.1.15
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -166,7 +166,7 @@ porcelain_endpoint <- R6::R6Class(
     ##' @param ... Additional arguments passed through to \code{run}
     plumber = function(req, res, ...) {
       tryCatch({
-        req$endpoint <- self$path
+        req$porcelain_endpoint <- self$path
         given <- list(
           path = plumber_path_args(req),
           query = req$porcelain_query,

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -166,6 +166,7 @@ porcelain_endpoint <- R6::R6Class(
     ##' @param ... Additional arguments passed through to \code{run}
     plumber = function(req, res, ...) {
       tryCatch({
+        req$endpoint <- self$path
         given <- list(
           path = plumber_path_args(req),
           query = req$porcelain_query,

--- a/R/logging.R
+++ b/R/logging.R
@@ -74,7 +74,9 @@ porcelain_log_postserialize <- function(logger) {
     now <- now_utc()
     logger$info(sprintf("response %s %s => %d (%d bytes)",
                         req$REQUEST_METHOD, req$PATH_INFO, res$status, size),
-                caller = "postserialize", request_received = req$received_time,
+                caller = "postserialize",
+                endpoint = req$endpoint,
+                request_received = req$received_time,
                 elapsed_ms = format_difftime_ms(now, req$received_time),
                 elapsed = format_difftime(now, req$received_time)
     )
@@ -102,6 +104,7 @@ logger_detailed <- function(logger, level, req, caller, ...) {
     caller = caller,
     method = req$REQUEST_METHOD,
     path = req$PATH_INFO,
+    endpoint = req$endpoint,
     query = req$porcelain_query,
     headers = as.list(req$HEADERS),
     body = describe_body(req$porcelain_body$value))

--- a/R/logging.R
+++ b/R/logging.R
@@ -75,7 +75,7 @@ porcelain_log_postserialize <- function(logger) {
     logger$info(sprintf("response %s %s => %d (%d bytes)",
                         req$REQUEST_METHOD, req$PATH_INFO, res$status, size),
                 caller = "postserialize",
-                endpoint = req$endpoint,
+                endpoint = req$porcelain_endpoint,
                 request_received = req$received_time,
                 elapsed_ms = format_difftime_ms(now, req$received_time),
                 elapsed = format_difftime(now, req$received_time)

--- a/R/logging.R
+++ b/R/logging.R
@@ -104,7 +104,7 @@ logger_detailed <- function(logger, level, req, caller, ...) {
     caller = caller,
     method = req$REQUEST_METHOD,
     path = req$PATH_INFO,
-    endpoint = req$endpoint,
+    endpoint = req$porcelain_endpoint,
     query = req$porcelain_query,
     headers = as.list(req$HEADERS),
     body = describe_body(req$porcelain_body$value))

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -70,17 +70,18 @@ test_that("Can log from endpoint with path variable", {
   expect_length(log, 4)
 
   expect_equal(log[[1]][c("caller", "msg")],
-               list(caller = "postroute", msg = "request GET /"))
+               list(caller = "postroute", msg = "request GET /path/value/123"))
 
   expect_equal(
     log[[2]][c("caller", "msg", "method", "path", "query", "headers",
                "endpoint")],
-    list(caller = "postroute", msg = "request", method = "GET", path = "/",
-         query = list(), headers = list(), endpoint = "/path/<type>/<id>"))
+    list(caller = "postroute", msg = "request", method = "GET",
+         path = "/path/value/123", query = list(), headers = list(),
+         endpoint = "/path/<type>/<id>"))
 
   expect_equal(log[[3]][c("caller", "msg", "endpoint")],
                list(caller = "postserialize",
-                    msg = "response GET / => 200 (49 bytes)",
+                    msg = "response GET /path/value/123 => 200 (47 bytes)",
                     endpoint = "/path/<type>/<id>"))
   datetime_pattern <- "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"
   expect_match(log[[3]]$request_received, datetime_pattern)
@@ -90,9 +91,9 @@ test_that("Can log from endpoint with path variable", {
   expect_equal(
     log[[4]][c("caller", "msg", "method", "path", "query", "headers",
                "body", "endpoint")],
-    list(caller = "postserialize", msg = "response", method = "GET", path = "/",
-         query = list(), headers = list(),
-         body = '{"status":"success","errors":null,"data":"hello"}',
+    list(caller = "postserialize", msg = "response", method = "GET",
+         path = "/path/value/123", query = list(), headers = list(),
+         body = '{"status":"success","errors":null,"data":"123"}',
          endpoint = "/path/<type>/<id>"))
 })
 
@@ -120,16 +121,19 @@ test_that("Can log from endpoint with query param", {
   expect_length(log, 4)
 
   expect_equal(log[[1]][c("caller", "msg")],
-               list(caller = "postroute", msg = "request GET /"))
+               list(caller = "postroute", msg = "request GET /query"))
 
   expect_equal(
-    log[[2]][c("caller", "msg", "method", "path", "query", "headers")],
-    list(caller = "postroute", msg = "request", method = "GET", path = "/",
-         query = list(), headers = list()))
+    log[[2]][c("caller", "msg", "method", "path", "query", "headers",
+               "endpoint")],
+    list(caller = "postroute", msg = "request", method = "GET", path = "/query",
+         query = list(param = "value"), headers = list(),
+         endpoint = "/query"))
 
-  expect_equal(log[[3]][c("caller", "msg")],
+  expect_equal(log[[3]][c("caller", "msg", "endpoint")],
                list(caller = "postserialize",
-                    msg = "response GET / => 200 (49 bytes)"))
+                    msg = "response GET /query => 200 (49 bytes)",
+                    endpoint = "/query"))
   datetime_pattern <- "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}"
   expect_match(log[[3]]$request_received, datetime_pattern)
   expect_match(log[[3]]$elapsed, "\\d+ \\w+")
@@ -137,10 +141,11 @@ test_that("Can log from endpoint with query param", {
 
   expect_equal(
     log[[4]][c("caller", "msg", "method", "path", "query", "headers",
-               "body")],
-    list(caller = "postserialize", msg = "response", method = "GET", path = "/",
-         query = list(), headers = list(),
-         body = '{"status":"success","errors":null,"data":"hello"}'))
+               "body", "endpoint")],
+    list(caller = "postserialize", msg = "response", method = "GET",
+         path = "/query", query = list(param = "value"), headers = list(),
+         body = '{"status":"success","errors":null,"data":"value"}',
+         endpoint = "/query"))
 })
 
 


### PR DESCRIPTION
After this PR the logger will
* Postroute info level logger will not change
* Postroute trace level logger will include the "endpoint"
* Postserialize info level logger will include the "endpoint"
* Postserialize trace level logger will include the "endpoint"

The endpoint here is the path that the `endpoint_*` function is listening on. So compared to the `req$PATH_INFO` it will be
|endpoint call | endpoint | PATH_INFO |
|--------------------| ------------- | ----------------- |
| `/path`              | `/path`         | `/path`           |
| `/path?param=value` | `/path` | `/path`      |
| `/path/<thing>`| `/path/<thing>`| `/path/value` |

We want to log the endpoint so that e.g. status endpoints which are at `/calibrate/status/<id>` will be the same log for every different calibrate ID.
